### PR TITLE
feat: delete listing

### DIFF
--- a/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -62,13 +63,33 @@ public class GlobalExceptionHandler {
 
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(
+  public ResponseEntity<ExceptionResponse> handleIllegalArgumentException(
           IllegalArgumentException exception) {
     ExceptionResponse response = new ExceptionResponse();
     response.setErrorCode("BAD_REQUEST");
     response.setErrorMessage(exception.getMessage());
     response.setTimestamp(LocalDateTime.now());
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(NoSuchElementException.class)
+  public ResponseEntity<ExceptionResponse> handleNoSuchElementException(
+          NoSuchElementException exception) {
+    ExceptionResponse response = new ExceptionResponse();
+    response.setErrorCode("BAD_REQUEST");
+    response.setErrorMessage("Item does not exist: " + exception.getMessage());
+    response.setTimestamp(LocalDateTime.now());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ExceptionResponse> handleNoSuchElementException(
+          HttpRequestMethodNotSupportedException exception) {
+    ExceptionResponse response = new ExceptionResponse();
+    response.setErrorCode("METHOD_NOT_ALLOWED");
+    response.setErrorMessage(exception.getMessage());
+    response.setTimestamp(LocalDateTime.now());
+    return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
   }
 
 }

--- a/src/main/java/com/codeplanks/home360/listing/ListingController.java
+++ b/src/main/java/com/codeplanks/home360/listing/ListingController.java
@@ -34,4 +34,16 @@ public class ListingController {
     return new ResponseEntity<>(allListings, HttpStatus.OK);
   }
 
+
+  @DeleteMapping("/listings/{listingId}")
+  public ResponseEntity<?> deleteListing(@PathVariable String listingId) {
+    SuccessDataResponse<Object> response = new SuccessDataResponse<>();
+    response.setMessage("Listing deleted successfully");
+    response.setStatus(HttpStatus.OK);
+    response.setData(listingService.deleteListing(listingId));
+    return new ResponseEntity<>(response, HttpStatus.OK);
+
+
+  }
+
 }

--- a/src/main/java/com/codeplanks/home360/listing/ListingService.java
+++ b/src/main/java/com/codeplanks/home360/listing/ListingService.java
@@ -1,6 +1,7 @@
 package com.codeplanks.home360.listing;
 
 import com.codeplanks.home360.config.JwtService;
+import com.codeplanks.home360.exception.UnauthorizedException;
 import com.codeplanks.home360.exception.UserNotFoundException;
 import com.codeplanks.home360.user.AppUser;
 import com.codeplanks.home360.user.UserRepository;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 
 
@@ -28,12 +31,7 @@ public class ListingService implements ListingServiceRepository {
   Logger logger = LoggerFactory.getLogger(ListingService.class);
 
   public ListingDTO createListing(Listing request) {
-    String authHeader = httpServletRequest.getHeader("Authorization");
-    String token = authHeader.substring(7);
-
-    String username = jwtService.extractUsername(token);
-    Integer userId = getUser(username).getId();
-
+    Integer userId = extractUserId();
     request.setAgentId(userId);
     request.setCreatedAt(LocalDateTime.now());
     request.setUpdatedAt(LocalDateTime.now());
@@ -49,9 +47,34 @@ public class ListingService implements ListingServiceRepository {
     return listingRepository.findAll();
   }
 
+  public Object deleteListing(String listingId) {
+    Integer userId = extractUserId();
+    Integer agentId = getAgentId(listingId);
+    if (!Objects.equals(agentId, userId)) {
+      throw new UnauthorizedException("You do not have the permission to delete this listing");
+    }
+    Optional<Listing> listing = listingRepository.findById(listingId);
+
+    listingRepository.deleteById(listingId);
+
+    return null;
+  }
+
+
   private AppUser getUser(String email) throws UserNotFoundException {
     return userRepository.findByEmail(email).orElseThrow(
             () -> new UserNotFoundException("Agent does not exist"));
   }
 
+  private Integer extractUserId() {
+    String authHeader = httpServletRequest.getHeader("Authorization");
+    String token = authHeader.substring(7);
+    String username = jwtService.extractUsername(token);
+    return getUser(username).getId();
+  }
+
+  private Integer getAgentId(String listingId) {
+    Listing listing = listingRepository.findById(listingId).orElseThrow();
+    return listing.getAgentId();
+  }
 }

--- a/src/main/java/com/codeplanks/home360/listing/ListingServiceRepository.java
+++ b/src/main/java/com/codeplanks/home360/listing/ListingServiceRepository.java
@@ -2,4 +2,5 @@ package com.codeplanks.home360.listing;
 
 public interface ListingServiceRepository {
   ListingDTO createListing(Listing request);
+  Object deleteListing(String listingId);
 }


### PR DESCRIPTION
## What does this PR do?
It deletes a listing using the `ID` of the listing.

## Description of Task to be completed
* Add delete method to `ListingServiceRepository`
* Implement the delete method in the service layer
* Call the delete method in the controller layer
* Add handler for `NoSuchElementException` and `HttpRequestMethodNotSupportedException`

## How should this be manually tested?
* Clone the repository
* Install dependencies
* Run the application
* Create an account or log in to an existing account
* Add authorization token to request header
* Using Postman or any other HTTP client,  set the request method to `DELETE`, navigate to `http://localhost:8080/api/v1/listings/<listingId>` 
* Example: 
```
curl --location --request DELETE 'http://localhost:8080/api/v1/listings/64bd7af452212f03ee0d215a' \
--header 'Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJtaW1vc2FAZXhhbXBsZS5jb20iLCJpYXQiOjE2OTExNjU1OTEsImV4cCI6MTY5MTE2NzAzMX0.MaS_t7DOEBGeeOgi_kEiK5M0b8tCtJtwNKkdcxYmIBAC_futfNBQmW18OBoJ64uYohnPMCxvuw_78PkuM0lAlw'

```
* You get the response:
```
{
    "status": "OK",
    "message": "Listing deleted successfully",
    "data": null
}

```

## Screenshots (if appropriate)



| Success      | Error | Unauthorized     |
| :---        |    :----:   |          ---: |
| <img width="1680" alt="Screenshot 2023-08-04 at 18 28 55" src="https://github.com/Hoxtygen/home360-server/assets/19408669/bb70cdb7-646b-484f-8c8f-59a22b089fde">      | <img width="1680" alt="Screenshot 2023-08-04 at 18 34 43" src="https://github.com/Hoxtygen/home360-server/assets/19408669/9da543c6-197d-42b7-a39b-1f4ef1ad69c9"> | <img width="1680" alt="Screenshot 2023-08-04 at 18 37 14" src="https://github.com/Hoxtygen/home360-server/assets/19408669/c61083e6-7c65-490a-a6c2-cb8818c86823">  |



## What are the relevant Jira board stories? 
[#HOM-8](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-8)

