### PR TITLE
chore: display only published listings

### DIFF
--- a/src/main/java/com/codeplanks/home360/utils/FilterableRepository.java
+++ b/src/main/java/com/codeplanks/home360/utils/FilterableRepository.java
@@ -20,6 +20,7 @@ public interface FilterableRepository<T> {
     Criteria annualRentCriteria = Criteria.where("cost.annualRent").gte(annualRent);
     Criteria apartmentTypeCriteria =
             Criteria.where("apartmentInfo.apartmentType").is(apartmentType);
+    Criteria apartmentAvailableCriteria = Criteria.where("available").is(true);
 
     if (city != null && !city.isEmpty()) {
       criteriaMap.put("address.city", cityCriteria);
@@ -29,6 +30,7 @@ public interface FilterableRepository<T> {
       criteriaMap.put("apartmentInfo.apartmentType", apartmentTypeCriteria);
     }
     criteriaMap.put("cost.annualRent", annualRentCriteria);
+    criteriaMap.put("available", apartmentAvailableCriteria);
 
     criteriaMap.values().forEach(query::addCriteria);
 


### PR DESCRIPTION
When users are searching through listings both published and unpublished listings are shown. This change ensures that only published listings are shown to the users

[Completes #HOM-50]