### PR TITLE
chore: make application async (HOM-65)

### DIFF
--- a/src/main/java/com/codeplanks/home360/Home360Application.java
+++ b/src/main/java/com/codeplanks/home360/Home360Application.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,6 +15,7 @@ import java.util.Map;
 
 @SpringBootApplication
 @RestController
+@EnableAsync(proxyTargetClass = true)
 public class Home360Application {
     public static void main(String[] args) {
         SpringApplication.run(Home360Application.class, args);
@@ -27,6 +29,5 @@ public class Home360Application {
                 new Date().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
         return new ResponseEntity<>(body, HttpStatus.OK);
     }
-
 
 }

--- a/src/main/java/com/codeplanks/home360/event/listener/RegistrationCompleteEventListener.java
+++ b/src/main/java/com/codeplanks/home360/event/listener/RegistrationCompleteEventListener.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationListener;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.io.UnsupportedEncodingException;
@@ -34,6 +35,7 @@ public class RegistrationCompleteEventListener implements
   private  String emailVerificationUrl;
 
   @Override
+  @Async
   public void onApplicationEvent(RegistrationCompleteEvent event) {
     appUser = event.getUser();
     String verificationToken = UUID.randomUUID().toString();

--- a/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.codeplanks.home360.exception;
 
+import com.sun.mail.util.MailConnectException;
 import jakarta.mail.AuthenticationFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -95,5 +98,15 @@ public class GlobalExceptionHandler {
 
     return new ResponseEntity<>(apiError, HttpStatus.NOT_IMPLEMENTED);
   }
+
+  @ExceptionHandler(value = {MailSendException.class, MailConnectException.class})
+  public ResponseEntity<ApiError> handleMailException(MailSendException exception) {
+    ApiError apiError = new ApiError();
+    apiError.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+    apiError.setMessage(exception.getMessage());
+    apiError.setTimestamp(LocalDateTime.now());
+    return  new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
 
 }


### PR DESCRIPTION
## What does this PR do?
Make the application asynchronous

## Description of Task to be completed?
* Add async annotation to `RegistrationCompleteEventListener`
* Add `@EnableAsync(proxyTargetClass = true)` to server root class

## How should this be manually tested?
* Clone the repository.
* On your PC open a terminal and run git clone <repo-url>.
* Open the pom.xml file and download dependencies.
* Run the application.
* Open Postman, Insomnia or any HTTP client.
* Disable access to the internet
* send a POST request to http://localhost:8080/api/v1/auth/register using the sample data below or that of your own
```
{
   "firstName": "Zea",
    "lastName": "Mays",
    "email": "zea@example.com",
    "phoneNumber": "09081235678",
    "address": "221B, Baker street London",
    "password": "Int3rnat!onalization"
}

```
* You should get a successful message like below
```
{
    "status": "CREATED",
    "message": "User registration successful",
    "data": "Registration Successful. A verification link have been sent to your email."
}
```

## What are the relevant Jira board stories?
[HOM-65](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-65)


[HOM-65]: https://wasiu-dev.atlassian.net/browse/HOM-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ