### PR TITLE
feat: set enquiry message as read (HOM-98)

### DIFF
--- a/src/main/java/com/codeplanks/home360/config/MongoConfig.java
+++ b/src/main/java/com/codeplanks/home360/config/MongoConfig.java
@@ -1,7 +1,6 @@
 package com.codeplanks.home360.config;
 
 import com.codeplanks.home360.utils.ArrayListToStringConverter;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -9,7 +8,6 @@ import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import java.util.List;
 
 @Configuration
-//@EnableAutoConfiguration(exclude = {AutoConf})
 public class MongoConfig {
   @Bean
   public MongoCustomConversions mongoCustomConversions() {

--- a/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
@@ -34,7 +34,7 @@ public class ListingEnquiryController {
   @Operation(
           summary = "Create a listing enquiry",
           description = "Create a listing enquiry",
-          tags = {"Listing enquiry", "Post"})
+          tags = {"POST"})
   @ApiResponses({
           @ApiResponse(
                   responseCode = "201",
@@ -69,7 +69,7 @@ public class ListingEnquiryController {
   @Operation(
           summary = "Get all listing enquiries of an agent",
           description = "Returns all listing enquiries of a given agent",
-          tags = {"listing enquires", "Get"}
+          tags = {"GET"}
   )
   @ApiResponses({
           @ApiResponse(
@@ -101,7 +101,7 @@ public class ListingEnquiryController {
   @Operation(
           summary = "Get listing enquiry by Id",
           description = "Returns a listing enquiry by specifying the Id",
-          tags = {"listing enquiry", "Get"}
+          tags = {"GET"}
   )
   @ApiResponses({
           @ApiResponse(
@@ -137,5 +137,55 @@ public class ListingEnquiryController {
     response.setMessage("Listing enquiry fetched successfully");
     response.setStatus(HttpStatus.OK);
     return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Operation(
+          summary = "Set listing enquiry to read",
+          description = "Set a given listing enquiry to read",
+          tags = {"PUT"}
+  )
+  @ApiResponses({
+          @ApiResponse(
+                  responseCode = "200",
+                  description = "Successfully set to read",
+                  content = {@Content(schema = @Schema(implementation = ListingEnquiry.class),
+                          mediaType = "application/json")}
+          ),
+          @ApiResponse(
+                  responseCode = "304",
+                  description = "Not modified. Message already set to read.",
+                  content = {@Content(schema = @Schema(implementation = ListingEnquiry.class),
+                          mediaType = "application/json")}
+          ),
+          @ApiResponse(
+                  responseCode = "401", description = "Authentication required",
+                  content = {@Content(schema = @Schema(implementation = ApiError.class),
+                          mediaType = "application/json")}
+          ),
+          @ApiResponse(
+                  responseCode = "403",
+                  description = "Forbidden - Not allowed to make update",
+                  content = {@Content(schema = @Schema(implementation = ApiError.class),
+                          mediaType = "application/json")}
+          ),
+          @ApiResponse(
+                  responseCode = "404",
+                  description = "Not Found - Listing enquiry with the given ID was not found",
+                  content = {@Content(schema = @Schema(implementation = ApiError.class),
+                          mediaType = "application/json")}
+          )
+  })
+  @PutMapping("listing-enquiry/{listingEnquiryId}/read")
+  public ResponseEntity<SuccessDataResponse<Boolean>> markMessageAsRead(@PathVariable String listingEnquiryId) {
+    SuccessDataResponse<Boolean> response = new SuccessDataResponse<>();
+    response.setData(listingEnquiryService.markMessageAsRead(listingEnquiryId));
+    if (!response.getData()) {
+      response.setMessage("Listing enquiry message already  read");
+      response.setStatus(HttpStatus.NOT_MODIFIED);
+    } else {
+      response.setMessage("Listing enquiry message marked as read");
+      response.setStatus(HttpStatus.OK);
+    }
+    return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
@@ -89,4 +89,7 @@ public class ListingEnquiry {
 
   @Field(name = "created_at", targetType = FieldType.DATE_TIME)
   private LocalDateTime createdAt;
+
+  @Field(name = "read", targetType = FieldType.BOOLEAN)
+  private boolean read = false;
 }

--- a/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailSendException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -126,5 +127,13 @@ public class GlobalExceptionHandler {
     apiError.setMessage(exception.getMessage());
     apiError.setTimestamp(LocalDateTime.now());
     return new ResponseEntity<>(apiError, HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ApiError> handleForbiddenException(AccessDeniedException exception) {
+    ApiError apiError = new ApiError(LocalDateTime.now(), HttpStatus.FORBIDDEN,
+            exception.getMessage());
+
+    return new ResponseEntity<>(apiError, HttpStatus.FORBIDDEN);
   }
 }

--- a/src/main/java/com/codeplanks/home360/exception/NotFoundException.java
+++ b/src/main/java/com/codeplanks/home360/exception/NotFoundException.java
@@ -1,5 +1,9 @@
 package com.codeplanks.home360.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundException extends  RuntimeException {
   public NotFoundException(String message) {
     super(message);

--- a/src/main/java/com/codeplanks/home360/exception/RefreshTokenExpiredException.java
+++ b/src/main/java/com/codeplanks/home360/exception/RefreshTokenExpiredException.java
@@ -1,5 +1,9 @@
 package com.codeplanks.home360.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
 public class RefreshTokenExpiredException extends RuntimeException {
   public RefreshTokenExpiredException(String message) {
     super(message);

--- a/src/main/java/com/codeplanks/home360/exception/UnAuthorizedException.java
+++ b/src/main/java/com/codeplanks/home360/exception/UnAuthorizedException.java
@@ -1,5 +1,9 @@
 package com.codeplanks.home360.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
 public class UnAuthorizedException extends  RuntimeException {
   public UnAuthorizedException(String message) {
     super(message);

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
@@ -11,4 +11,5 @@ public interface ListingEnquiryService {
 
   ListingEnquiry getListingEnquiryById(String enquiryMessageId);
 
+  Boolean markMessageAsRead(String enquiryMessageId);
 }


### PR DESCRIPTION
## What does this PR do?
 * Marks a listing enquiry message as read

## Description of the tasks to be completed
* Update the service layer interface with the method to mark as read
* Implements service layer
* Implements controller layer
* Add documentation

## How should this be manually tested?
* Clone the repository.
* On your PC open a terminal and run git clone <repo_url>.
* Open the pom.xml file and download dependencies.
* Run the application.
* Login with your credentials and copy the  access token
* Send a `PUT` request to `http://localhost:8080/api/v1/listing-enquiry/${listingEnquiryId}/read`
```
curl --location --request PUT 'http://localhost:8080/api/v1/listing-enquiry/${listingEnquiryId}/read' \
--header 'Authorization: Bearer ${access_token}'
```

## What are the relevant Jira board stories?
[HOM-98](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-98)

[HOM-98]: https://wasiu-dev.atlassian.net/browse/HOM-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ