### PR TITLE
feat: send user in-app messages (HOM-95)

### DIFF
--- a/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
@@ -4,6 +4,8 @@ package com.codeplanks.home360.controller;
 import com.codeplanks.home360.domain.listing.PaginatedResponse;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryDTO;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReply;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReplyDTO;
 import com.codeplanks.home360.event.ListingEnquiryEvent;
 import com.codeplanks.home360.exception.ApiError;
 import com.codeplanks.home360.service.ListingEnquiryServiceImpl;
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
@@ -187,5 +190,15 @@ public class ListingEnquiryController {
       response.setStatus(HttpStatus.OK);
     }
     return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @PostMapping("/listing-enquiry/{enquiryId}/message")
+  public ResponseEntity<SuccessDataResponse<ListingEnquiryMessageReply>>sendEnquiryReply(@PathVariable String enquiryId,
+                                                                                         @RequestBody @Valid ListingEnquiryMessageReplyDTO replyMessage){
+    SuccessDataResponse<ListingEnquiryMessageReply> response = new SuccessDataResponse<>();
+    response.setData(listingEnquiryService.addReplyMessage(enquiryId, replyMessage));
+    response.setStatus(HttpStatus.CREATED);
+    response.setMessage("message posted.");
+    return  new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
@@ -132,9 +132,10 @@ public class ListingEnquiryController {
           )
   })
   @GetMapping("/listing-enquiries/{listingEnquiryId}")
-  public ResponseEntity<SuccessDataResponse<ListingEnquiry>> getAgentListingEnquiryById
-          (@PathVariable("listingEnquiryId") @Parameter(name = "listingEnquiryId", description =
-                  "Listing enquiry Id", example = "66ac91c8cb3294535d04e0e3") String listingEnquiryId) {
+  public ResponseEntity<SuccessDataResponse<ListingEnquiry>> getAgentListingEnquiryById(
+          @PathVariable("listingEnquiryId") @Parameter(name = "listingEnquiryId",
+                  description = "Listing enquiry Id", example = "66ac91c8cb3294535d04e0e3")
+          String listingEnquiryId) {
     SuccessDataResponse<ListingEnquiry> response = new SuccessDataResponse<>();
     response.setData(listingEnquiryService.getListingEnquiryById(listingEnquiryId));
     response.setMessage("Listing enquiry fetched successfully");
@@ -179,7 +180,8 @@ public class ListingEnquiryController {
           )
   })
   @PutMapping("listing-enquiry/{listingEnquiryId}/read")
-  public ResponseEntity<SuccessDataResponse<Boolean>> markMessageAsRead(@PathVariable String listingEnquiryId) {
+  public ResponseEntity<SuccessDataResponse<Boolean>> markMessageAsRead(
+          @PathVariable String listingEnquiryId) {
     SuccessDataResponse<Boolean> response = new SuccessDataResponse<>();
     response.setData(listingEnquiryService.markMessageAsRead(listingEnquiryId));
     if (!response.getData()) {
@@ -192,13 +194,48 @@ public class ListingEnquiryController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @Operation(
+          summary = "Sends messages between registered users",
+          description = "Allow registered users to send messages between themselves in response " +
+                  "to listing enquiries",
+          tags = {"POST"}
+  )
+  @ApiResponses({
+          @ApiResponse(
+                  responseCode = "201",
+                  description = "Created successfully",
+                  content = {@Content(schema = @Schema(implementation =
+                          ListingEnquiryMessageReply.class),
+                          mediaType = "application/json")}
+          ),
+          @ApiResponse(
+                  responseCode = "400",
+                  description = "Bad request",
+                  content = {@Content(schema = @Schema(implementation = ApiError.class),
+                          mediaType = "application/json")}
+          ),
+          @ApiResponse(
+                  responseCode = "401",
+                  description = "Authentication required",
+                  content = {@Content(schema = @Schema(implementation = ApiError.class),
+                          mediaType = "application/json")}
+          ),
+          @ApiResponse(
+                  responseCode = "404",
+                  description = "Not Found - The listing enquiry ID, sender or receiver was " +
+                          "not found",
+                  content = {@Content(schema = @Schema(implementation = ApiError.class),
+                          mediaType = "application/json")}
+          )
+  })
   @PostMapping("/listing-enquiry/{enquiryId}/message")
-  public ResponseEntity<SuccessDataResponse<ListingEnquiryMessageReply>>sendEnquiryReply(@PathVariable String enquiryId,
-                                                                                         @RequestBody @Valid ListingEnquiryMessageReplyDTO replyMessage){
+  public ResponseEntity<SuccessDataResponse<ListingEnquiryMessageReply>> sendEnquiryReply(
+          @PathVariable String enquiryId,
+          @RequestBody @Valid ListingEnquiryMessageReplyDTO replyMessage) {
     SuccessDataResponse<ListingEnquiryMessageReply> response = new SuccessDataResponse<>();
     response.setData(listingEnquiryService.addReplyMessage(enquiryId, replyMessage));
     response.setStatus(HttpStatus.CREATED);
     response.setMessage("message posted.");
-    return  new ResponseEntity<>(response, response.getStatus());
+    return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
@@ -14,6 +14,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldType;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
@@ -92,4 +94,7 @@ public class ListingEnquiry {
 
   @Field(name = "read", targetType = FieldType.BOOLEAN)
   private boolean read = false;
+
+@Field(name = "replies", targetType = FieldType.ARRAY)
+  private List<ListingEnquiryMessageReply> replies = new ArrayList<>();
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryDTO.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -27,5 +28,7 @@ public class ListingEnquiryDTO {
   private String commercialPurpose;
   private String listingId;
   private Integer agentId;
+  private boolean read;
+  private List<ListingEnquiryMessageReply> replies;
   private LocalDateTime createdAt;
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMapper.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMapper.java
@@ -16,6 +16,8 @@ public class ListingEnquiryMapper {
             listingEnquiry.getCommercialPurpose(),
             listingEnquiry.getListingId(),
             listingEnquiry.getAgentId(),
+            listingEnquiry.isRead(),
+            listingEnquiry.getReplies(),
             listingEnquiry.getCreatedAt()
     );
   }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReply.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReply.java
@@ -17,8 +17,8 @@ import java.time.LocalDateTime;
 public class ListingEnquiryMessageReply {
   @Id
   private String id;
-  private  int sender;
-  private int receiver;
+  private  int senderId;
+  private int receiverId;
   private  String content;
   private LocalDateTime createdAt;
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReply.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReply.java
@@ -1,0 +1,24 @@
+package com.codeplanks.home360.domain.listingEnquiries;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_NULL)
+public class ListingEnquiryMessageReply {
+  @Id
+  private String id;
+  private  int sender;
+  private int receiver;
+  private  String content;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
@@ -1,0 +1,21 @@
+package com.codeplanks.home360.domain.listingEnquiries;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ListingEnquiryMessageReplyDTO {
+  @NotNull(message = "sender is required")
+  private  int sender;
+
+  @NotNull(message = "receiver is required")
+  private int receiver;
+
+  @NotNull(message = "message content is required")
+  @Size(min = 2,  message = "message should be at least 2 characters")
+  private  String content;
+
+}

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
@@ -8,11 +8,11 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class ListingEnquiryMessageReplyDTO {
-  @NotNull(message = "sender is required")
-  private  int sender;
+  @NotNull(message = "sender ID is required")
+  private  int senderId;
 
-  @NotNull(message = "receiver is required")
-  private int receiver;
+  @NotNull(message = "receiver ID is required")
+  private int receiverId;
 
   @NotNull(message = "message content is required")
   @Size(min = 2,  message = "message should be at least 2 characters")

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
@@ -3,6 +3,8 @@ package com.codeplanks.home360.service;
 import com.codeplanks.home360.domain.listing.PaginatedResponse;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryDTO;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReply;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReplyDTO;
 
 public interface ListingEnquiryService {
   ListingEnquiryDTO makeEnquiry(ListingEnquiry enquiryRequest);
@@ -12,4 +14,6 @@ public interface ListingEnquiryService {
   ListingEnquiry getListingEnquiryById(String enquiryMessageId);
 
   Boolean markMessageAsRead(String enquiryMessageId);
+
+  ListingEnquiryMessageReply addReplyMessage(String enquiryId, ListingEnquiryMessageReplyDTO reply);
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -131,7 +131,7 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
       throw new NotFoundException("EnquiryId does not exist");
     }
     if (result.getModifiedCount() == 0) {
-      throw new RuntimeException("EnquiryId does not exist");
+      throw new NotFoundException("EnquiryId does not exist");
     }
 
     return reply;

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -83,7 +83,7 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   @Override
   public ListingEnquiryMessageReply addReplyMessage(String enquiryMessageId,
                                                     ListingEnquiryMessageReplyDTO reply) {
-    validateUserIds(reply.getSender(), reply.getReceiver());
+    validateUserIds(reply.getSenderId(), reply.getReceiverId());
     Query query = createQuery(enquiryMessageId);
     return addEnquiryReply(query, reply);
   }
@@ -118,8 +118,8 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
       throw new IllegalArgumentException("Message reply cannot be null");
     }
     ListingEnquiryMessageReply reply = ListingEnquiryMessageReply.builder()
-            .sender(messageReply.getSender())
-            .receiver(messageReply.getReceiver())
+            .senderId(messageReply.getSenderId())
+            .receiverId(messageReply.getReceiverId())
             .content(messageReply.getContent())
             .id(UUID.randomUUID().toString())
             .createdAt(LocalDateTime.now())


### PR DESCRIPTION
## What does this PR do?
* Allows 2  registered users to send in-app messages to each other in response to a listing enquiry

## Description of the task to be completed
* Update service layer interface with method to send message
* Implement service layer
* Implement controller layer
* Add documentation

## How should this be manually tested?
* Clone the repository.
* On your PC open a terminal and run git clone <repo_url>.
* Open the pom.xml file and download dependencies.
* Run the application.
* Login with your credentials and copy the  access token
* Send a `POST` request to `http://localhost:8080/api/v1/listing-enquiry/${listingEnquiryId}/message`
```
curl --location 'http://localhost:8080/api/v1/listing-enquiry/${listingEnquiryId}/message' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ${access_token}' \
--data '{
    "senderId": senderId,
    "receiverId": receiverId,
    "content": "content"
    
}'
```

## What are the relevant Jira board stories?
[HOM-95](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-95)

[HOM-95]: https://wasiu-dev.atlassian.net/browse/HOM-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ