### PR TITLE
feat: get all listing views (HOM-148)

### DIFF
--- a/src/main/java/com/codeplanks/home360/controller/ListingViewController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingViewController.java
@@ -58,6 +58,16 @@ public class ListingViewController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @Operation(
+      summary = "Get all listing views",
+      description = "Returns all listing views",
+      tags = {"GET"})
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "Listing views retrieved successfully",
+        content = {@Content(mediaType = "application/json")}),
+  })
   @GetMapping()
   public ResponseEntity<SuccessDataResponse<List<ListingView>>> getAllViews() {
     SuccessDataResponse<List<ListingView>> response = new SuccessDataResponse<>();

--- a/src/main/java/com/codeplanks/home360/controller/ListingViewController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingViewController.java
@@ -12,14 +12,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -57,6 +55,15 @@ public class ListingViewController {
     response.setData(listingViewService.saveListingView(request));
     response.setMessage("Views created");
     response.setStatus(HttpStatus.CREATED);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping()
+  public ResponseEntity<SuccessDataResponse<List<ListingView>>> getAllViews() {
+    SuccessDataResponse<List<ListingView>> response = new SuccessDataResponse<>();
+    response.setData(listingViewService.getAllListingViews());
+    response.setMessage("Listing views retrieved successfully");
+    response.setStatus(HttpStatus.OK);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingViewService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingViewService.java
@@ -3,7 +3,10 @@ package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listingView.ListingView;
 import com.codeplanks.home360.domain.listingView.ListingViewDTO;
+import java.util.List;
 
 public interface ListingViewService {
   ListingView saveListingView(ListingViewDTO request);
+
+  List<ListingView> getAllListingViews();
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingViewServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingViewServiceImpl.java
@@ -5,6 +5,7 @@ import com.codeplanks.home360.domain.listingView.ListingView;
 import com.codeplanks.home360.domain.listingView.ListingViewDTO;
 import com.codeplanks.home360.repository.ListingViewRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,5 +25,10 @@ public class ListingViewServiceImpl implements ListingViewService {
             .createdAt(LocalDateTime.now())
             .build();
     return viewRepository.save(listingView);
+  }
+
+  @Override
+  public List<ListingView> getAllListingViews() {
+    return viewRepository.findAll();
   }
 }

--- a/src/test/java/com/codeplanks/home360/service/ListingViewServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingViewServiceTest.java
@@ -12,9 +12,11 @@ import com.codeplanks.home360.domain.listing.Listing;
 import com.codeplanks.home360.domain.listingView.ListingView;
 import com.codeplanks.home360.domain.listingView.ListingViewDTO;
 import com.codeplanks.home360.exception.NotFoundException;
-import com.codeplanks.home360.repository.ListingRepository;
 import com.codeplanks.home360.repository.ListingViewRepository;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,6 @@ class ListingViewServiceTest {
   @Mock ListingViewRepository listingViewRepository;
 
   @Mock ListingServiceImpl listingService;
-  @Mock ListingRepository listingRepository;
 
   @BeforeEach
   void setUp() {}
@@ -93,5 +94,39 @@ class ListingViewServiceTest {
         assertThrows(NotFoundException.class, () -> listingViewService.saveListingView(request));
     // Then
     assertEquals("Listing not found", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("Get all listing views")
+  void givenListingViewsExistWhenGetAllListingViewsThenReturnListOfListingViews() {
+    // Given
+    ListingView listingView1 = new ListingView();
+    ListingView listingView2 = new ListingView();
+    ListingView listingView3 = new ListingView();
+    ListingView listingView4 = new ListingView();
+    List<ListingView> listingViews =
+        Arrays.asList(listingView1, listingView2, listingView3, listingView4);
+    given(listingViewRepository.findAll()).willReturn(listingViews);
+    // When
+    List<ListingView> result = listingViewService.getAllListingViews();
+    // Then
+    assertNotNull(result);
+    assertEquals(4, result.size());
+    verify(listingViewRepository, times(1)).findAll();
+  }
+
+  @Test
+  @DisplayName("Empty listing views")
+  void givenNoListingViewsExistWhenAllListingViewsThenReturnEmptyList() {
+    // Given
+    given(listingViewRepository.findAll()).willReturn(Collections.emptyList());
+
+    // When
+    List<ListingView> result = listingViewService.getAllListingViews();
+
+    // Then
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    verify(listingViewRepository, times(1)).findAll();
   }
 }


### PR DESCRIPTION
## What does this PR do?
* Retrieves all listing views record in the database

## Description of tasks to be done
* Create `Repository`, `Service` and `Controller` layers implementation to fetch all listing views.
* Write unit test.
* Update documentation.

## How can this be manually tested
* Clone the repository
* Open a terminal and `cd` to the project directories
* Install dependencies
* Run the project
* Send a `GET` request to `http://localhost:8080/api/v1/listing-views`
```
curl --location 'http://localhost:8080/api/v1/listing-views' \
--header 'Authorization: Bearer {token}'

```

```
// response
{
    "status": "OK",
    "message": "Listing views retrieved successfully",
    "data": [
        {
            "id": "6755cf1f1fd7f41a3149980f",
            "listingId": "663b268e5512f1692718c3aa",
            "timestamp": "2024-12-08T15:52:36"
        },
        {
            "id": "675691bc6f2dff4520e5e335",
            "listingId": "663b268e5512f1692718c3aa",
            "timestamp": "2024-12-08T17:52:36",
            "createdAt": "2024-12-09T07:44:12.107"
        }
    ]
}

```

## What are the relevant Jira board story?
[HOM-148](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-148)


[HOM-148]: https://wasiu-dev.atlassian.net/browse/HOM-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ