### PR TITLE
Feat: implement secure refresh token handling (HOM-151)

### DIFF
--- a/src/main/java/com/codeplanks/home360/config/RateLimitingFilter.java
+++ b/src/main/java/com/codeplanks/home360/config/RateLimitingFilter.java
@@ -36,7 +36,6 @@ public class RateLimitingFilter implements Filter {
     boolean isAuthenticated = httpServletRequest.getUserPrincipal() != null;
 
     String path = httpServletRequest.getRequestURI();
-    System.out.println("Path: " + path);
 
     if (path.startsWith("/swagger") || path.startsWith("/v1/api-docs")) {
       chain.doFilter(request, response);

--- a/src/main/java/com/codeplanks/home360/config/SecurityConfiguration.java
+++ b/src/main/java/com/codeplanks/home360/config/SecurityConfiguration.java
@@ -4,6 +4,7 @@ package com.codeplanks.home360.config;
 import com.codeplanks.home360.exception.CustomAccessDeniedHandler;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -28,6 +29,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfiguration {
   private final JwtAuthenticationFilter jwtAuthFilter;
   private final AuthenticationProvider authenticationProvider;
+
+  @Value("${cors.allowed-origins}")
+  private String allowedOrigins;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -73,9 +77,10 @@ public class SecurityConfiguration {
   @Bean
   CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(List.of("*"));
-    configuration.setAllowedMethods(List.of("*"));
+    configuration.setAllowedOrigins(List.of(allowedOrigins.split(",")));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
     configuration.setAllowedHeaders(List.of("*"));
+    configuration.setAllowCredentials(true);
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     return source;

--- a/src/main/java/com/codeplanks/home360/controller/AuthenticationController.java
+++ b/src/main/java/com/codeplanks/home360/controller/AuthenticationController.java
@@ -5,9 +5,11 @@ import com.codeplanks.home360.domain.auth.*;
 import com.codeplanks.home360.domain.token.TokenRequest;
 import com.codeplanks.home360.domain.token.TokenResponse;
 import com.codeplanks.home360.exception.ApiError;
+import com.codeplanks.home360.exception.UnAuthorizedException;
 import com.codeplanks.home360.service.AuthenticationServiceImpl;
 import com.codeplanks.home360.service.RefreshTokenServiceImpl;
 import com.codeplanks.home360.service.VerificationTokenServiceImpl;
+import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.codeplanks.home360.utils.SuccessDataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,6 +18,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.UnsupportedEncodingException;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +41,7 @@ public class AuthenticationController {
   private final AuthenticationServiceImpl authenticationServiceImpl;
   private final RefreshTokenServiceImpl refreshTokenService;
   private final VerificationTokenServiceImpl verificationTokenService;
+  private final AuthenticationUtils authenticationUtils;
 
   @Operation(
       summary = "Register user",
@@ -101,8 +107,25 @@ public class AuthenticationController {
         }),
   })
   @PostMapping("/login")
-  public ResponseEntity<AuthenticationResponse> login(@RequestBody AuthenticationRequest request) {
-    return new ResponseEntity<>(authenticationServiceImpl.login(request), HttpStatus.OK);
+  public ResponseEntity<SuccessDataResponse<AuthenticationResponse>> login(
+      @RequestBody AuthenticationRequest request, HttpServletResponse response) {
+    SuccessDataResponse<AuthenticationResponse> result = new SuccessDataResponse<>();
+    AuthenticationResponse authResponse = authenticationServiceImpl.login(request);
+
+    Cookie refreshTokenCookie =
+        new Cookie("refreshToken", authResponse.getToken().getRefreshToken());
+    refreshTokenCookie.setHttpOnly(true);
+    refreshTokenCookie.setSecure(!authenticationUtils.isLocalEnvironment());
+    refreshTokenCookie.setPath("/");
+    refreshTokenCookie.setMaxAge(60 * 60 * 24 * 3);
+
+    response.addCookie(refreshTokenCookie);
+
+    result.setData(authResponse);
+    result.setMessage("Login successful");
+    result.setStatus(HttpStatus.OK);
+
+    return new ResponseEntity<>(result, HttpStatus.OK);
   }
 
   @Operation(
@@ -208,12 +231,41 @@ public class AuthenticationController {
   })
   @PostMapping("/refreshToken")
   public ResponseEntity<SuccessDataResponse<TokenResponse>> getRefreshToken(
-      @RequestBody TokenRequest tokenRequest) {
-    SuccessDataResponse<TokenResponse> response = new SuccessDataResponse<>();
-    response.setData(refreshTokenService.refreshToken(tokenRequest));
-    response.setMessage("Success");
-    response.setStatus(HttpStatus.CREATED);
-    return new ResponseEntity<>(response, HttpStatus.CREATED);
+      HttpServletRequest request, HttpServletResponse response) {
+    SuccessDataResponse<TokenResponse> result = new SuccessDataResponse<>();
+
+    String refreshToken = null;
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if ("refreshToken".equals(cookie.getName())) {
+          refreshToken = cookie.getValue();
+          break;
+        }
+      }
+    }
+
+    if (refreshToken == null) {
+      throw new UnAuthorizedException("Refresh token is missing");
+    }
+
+    TokenRequest tokenRequest = new TokenRequest();
+    tokenRequest.setToken(refreshToken);
+    TokenResponse tokenResponse = refreshTokenService.refreshToken(tokenRequest);
+
+    Cookie refreshTokenCookie = new Cookie("refreshToken", tokenRequest.getToken());
+    refreshTokenCookie.setHttpOnly(true);
+    refreshTokenCookie.setSecure(!authenticationUtils.isLocalEnvironment());
+    refreshTokenCookie.setPath("/");
+    refreshTokenCookie.setMaxAge(60 * 60 * 24 * 3);
+
+    response.addCookie(refreshTokenCookie);
+
+    result.setData(tokenResponse);
+    result.setMessage("Success");
+    result.setStatus(HttpStatus.CREATED);
+
+    return new ResponseEntity<>(result, HttpStatus.CREATED);
   }
 
   @Operation(

--- a/src/main/java/com/codeplanks/home360/converter/StringToListingEnquiryMessageReplyArrayListConverter.java
+++ b/src/main/java/com/codeplanks/home360/converter/StringToListingEnquiryMessageReplyArrayListConverter.java
@@ -25,7 +25,6 @@ public class StringToListingEnquiryMessageReplyArrayListConverter
   public ArrayList<ListingEnquiryMessageReply> convert(@NonNull String source) {
 
     try {
-      System.out.println("Converting Json string to List " + source);
       return objectMapper.readValue(
           source,
           objectMapper

--- a/src/main/java/com/codeplanks/home360/domain/auth/AuthenticationResponse.java
+++ b/src/main/java/com/codeplanks/home360/domain/auth/AuthenticationResponse.java
@@ -15,11 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AuthenticationResponse {
-  private Integer id;
-  private Integer status;
-  private String message;
   private String firstName;
   private String lastName;
-  private String email;
   private TokenResponse token;
 }

--- a/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
@@ -109,12 +109,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
               .build();
       return AuthenticationResponse.builder()
           .token(tokenResponse)
-          .id(user.getId())
           .firstName(user.getFirstName())
           .lastName(user.getLastName())
-          .email(user.getEmail())
-          .message("User login successful")
-          .status(200)
           .build();
 
     } catch (BadCredentialsException exception) {

--- a/src/main/java/com/codeplanks/home360/utils/AuthenticationUtils.java
+++ b/src/main/java/com/codeplanks/home360/utils/AuthenticationUtils.java
@@ -1,7 +1,6 @@
 /* (C)2024 */
 package com.codeplanks.home360.utils;
 
-import java.util.Arrays;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -25,7 +24,6 @@ public class AuthenticationUtils {
 
   public boolean isLocalEnvironment() {
     String[] activeProfiles = environment.getActiveProfiles();
-    System.out.println("profiles: " + Arrays.toString(activeProfiles));
     for (String profile : activeProfiles) {
       if ("dev".equalsIgnoreCase(profile) || "docker".equalsIgnoreCase(profile)) {
         return true;

--- a/src/main/java/com/codeplanks/home360/utils/AuthenticationUtils.java
+++ b/src/main/java/com/codeplanks/home360/utils/AuthenticationUtils.java
@@ -1,6 +1,9 @@
 /* (C)2024 */
 package com.codeplanks.home360.utils;
 
+import java.util.Arrays;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -8,6 +11,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AuthenticationUtils {
+  @Autowired private Environment environment;
+
   public boolean isAuthenticated() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     return authentication.isAuthenticated() && !isAnonymous();
@@ -16,5 +21,16 @@ public class AuthenticationUtils {
   public boolean isAnonymous() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     return authentication instanceof AnonymousAuthenticationToken;
+  }
+
+  public boolean isLocalEnvironment() {
+    String[] activeProfiles = environment.getActiveProfiles();
+    System.out.println("profiles: " + Arrays.toString(activeProfiles));
+    for (String profile : activeProfiles) {
+      if ("dev".equalsIgnoreCase(profile) || "docker".equalsIgnoreCase(profile)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/resources/application-sample-dev.yml
+++ b/src/main/resources/application-sample-dev.yml
@@ -7,6 +7,9 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+cors:
+  allowed-origins: "http://localhost:3000"
+
 spring:
   application:
     name: Home360

--- a/src/main/resources/application-sample-docker.yml
+++ b/src/main/resources/application-sample-docker.yml
@@ -1,6 +1,15 @@
 server:
   port: <port>
 
+springdoc:
+  api-docs:
+    path: /v3/api/docs
+  swagger-ui:
+    path: /swagger-ui.html
+
+cors:
+  allowed-origins: "http://localhost:3000"
+
 spring:
   application:
     name: Home360

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    default: dev
+    active: dev
 
 
 springdoc:

--- a/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
@@ -181,12 +181,9 @@ class AuthenticationServiceTest {
     // Then - verify the output
     assertAll(
         () -> assertThat(response).isNotNull(),
-        () -> assertThat(response.getEmail()).isEqualTo("elaeis@example.com"),
         () -> assertThat(response.getFirstName()).isEqualTo("Elaeis"),
         () -> assertThat(response.getLastName()).isEqualTo("Guineensis"),
-        () -> assertThat(response.getToken().getAccessToken()).isEqualTo(token),
-        () -> assertThat(response.getMessage()).isEqualTo("User login successful"),
-        () -> assertThat(response.getStatus()).isEqualTo(200));
+        () -> assertThat(response.getToken().getAccessToken()).isEqualTo(token));
 
     verify(authenticationManager, times(1))
         .authenticate(any(UsernamePasswordAuthenticationToken.class));


### PR DESCRIPTION
## What does this PR do?
* Implements secure refresh token handling

## Description of tasks be completed
* Add refresh token to cookie in HttpServletResponse header in `/auth/login` endpoint
* Add refresh token to cookie in HttpServletRequest header in `auth/refreshToken`
* Configure profile-based allowed origins
* 

##  How can this be manually tested
* Clone the repository
* Open a terminal and `cd` to the project directories
* Install dependencies
* Run the project
* Send a `POST` request to `http://localhost:8080/api/v1/auth/login`
* Inspect the response header for refresh token cookie.
```
Set-Cookie: refreshToken=fa859d24-28f5-483f-b4d9-13ea56582507; Max-Age=259200; Expires=Tue, 17 Dec 2024 18:38:11 GMT; Path=/; HttpOnly

```

## What are the relevant JIra board story
[HOM-151](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-151)

[HOM-151]: https://wasiu-dev.atlassian.net/browse/HOM-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ