### PR TITLE
bugfix: resolve time mismatch (HOM-153)

### DIFF
--- a/src/main/java/com/codeplanks/home360/domain/listingView/ListingViewDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingView/ListingViewDTO.java
@@ -14,8 +14,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class ListingViewDTO {
-  private String id;
-
   @NotBlank(message = "Listing ID is required")
   private String listingId;
 

--- a/src/main/java/com/codeplanks/home360/service/ListingViewServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingViewServiceImpl.java
@@ -6,6 +6,8 @@ import com.codeplanks.home360.domain.listingView.ListingView;
 import com.codeplanks.home360.domain.listingView.ListingViewDTO;
 import com.codeplanks.home360.repository.ListingViewRepository;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -21,10 +23,13 @@ public class ListingViewServiceImpl implements ListingViewService {
   @Override
   public ListingView saveListingView(ListingViewDTO request) {
     listingService.findListingById(request.getListingId());
+    ZonedDateTime utcTimestamp = request.getTimestamp().atZone(ZoneId.of("UTC"));
+    LocalDateTime localTimestamp =
+        utcTimestamp.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
     ListingView listingView =
         ListingView.builder()
             .listingId(request.getListingId())
-            .timestamp(request.getTimestamp())
+            .timestamp(localTimestamp)
             .createdAt(LocalDateTime.now())
             .build();
     return viewRepository.save(listingView);


### PR DESCRIPTION
## What does this PR do?
* Resolve the time mismatch between createdAt view timestamp. 

## Description of tasks to be completed
* Convert the received timestamp to the desired time zone before saving to the database.

## How can this be manually tested?
* Clone the repository
* Open a terminal and `cd` to the project directories
* Install dependencies
* Run the project
* Send a `POST` request to `http://localhost:8080/api/v1/listing-views`

```
curl --location 'http://localhost:8080/api/v1/listing-views' \
--header 'Content-Type: application/json' \
--data '{
    "listingId": "65ae09dd1e37bd55a43d5601",
    "timestamp": "2024-12-19T17:15:38.383"
}
'
```

```
// response
{
            "id": "676454bae43e504ac0513675",
            "listingId": "65ae09dd1e37bd55a43d5601",
            "timestamp": "2024-12-19T18:15:38.383",
            "createdAt": "2024-12-19T18:15:38.476"
        },

```
* Contrast to previous response
```
 {
            "id": "676063f23dd689154c2b2fac",
            "listingId": "65ae09dd1e37bd55a43d5601",
            "timestamp": "2024-12-16T17:31:29.757",
            "createdAt": "2024-12-16T18:31:30.245"
        },



## What are the relevant Jira board stories?
[HOM-153](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-153)

[HOM-153]: https://wasiu-dev.atlassian.net/browse/HOM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ