### PR TITLE
feat: implement getting views count (HOM-154)

### DIFF
--- a/src/main/java/com/codeplanks/home360/Home360Application.java
+++ b/src/main/java/com/codeplanks/home360/Home360Application.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360;
 
 import org.springframework.boot.SpringApplication;
@@ -7,7 +7,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.bind.annotation.RestController;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.codeplanks.home360")
 @RestController
 @EnableAsync(proxyTargetClass = true)
 @EnableTransactionManagement

--- a/src/main/java/com/codeplanks/home360/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeplanks/home360/config/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.config;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -26,7 +26,7 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-  private final JwtService jwtService;
+  @Autowired private final JwtService jwtService;
   private final UserDetailsService userDetailsService;
   Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 

--- a/src/main/java/com/codeplanks/home360/controller/ListingController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingController.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.controller;
 
 import com.codeplanks.home360.domain.listing.*;
@@ -88,8 +88,8 @@ public class ListingController {
         content = {@Content(mediaType = "application/json")}),
   })
   @GetMapping
-  public ResponseEntity<SuccessDataResponse<List<Listing>>> getAllListings() {
-    SuccessDataResponse<List<Listing>> allListings = new SuccessDataResponse<>();
+  public ResponseEntity<SuccessDataResponse<List<ListingWithViewCountDTO>>> getAllListings() {
+    SuccessDataResponse<List<ListingWithViewCountDTO>> allListings = new SuccessDataResponse<>();
     allListings.setData(listingService.allListings());
     allListings.setMessage("Listings retrieved successfully");
     allListings.setStatus(HttpStatus.OK);

--- a/src/main/java/com/codeplanks/home360/domain/listing/ListingWithAgentInfo.java
+++ b/src/main/java/com/codeplanks/home360/domain/listing/ListingWithAgentInfo.java
@@ -1,3 +1,4 @@
+/* (C)2025 */
 package com.codeplanks.home360.domain.listing;
 
 import lombok.*;
@@ -7,6 +8,6 @@ import lombok.*;
 @Setter
 @Builder
 public class ListingWithAgentInfo {
-  private Listing listing;
+  private ListingWithViewCountDTO listing;
   private ListingAgentInfo agentInfo;
 }

--- a/src/main/java/com/codeplanks/home360/domain/listing/ListingWithViewCountDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listing/ListingWithViewCountDTO.java
@@ -1,0 +1,37 @@
+/* (C)2025 */
+package com.codeplanks.home360.domain.listing;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY, content = JsonInclude.Include.NON_NULL)
+public class ListingWithViewCountDTO {
+  private String id;
+  private String title;
+  private String description;
+  private String furnishing;
+  private String position;
+  private String miscellaneous;
+  private Address address;
+  private Integer agent_id;
+  private LocalDateTime available_from;
+  private ListingCost cost;
+  private List<String> details;
+  private FacilityQuality facility_quality;
+  private PetsAllowed pets_allowed;
+  private ApartmentInfo apartment_info;
+  private List<String> application_docs;
+  private List<String> apartment_images;
+  private int viewCount;
+  private LocalDateTime created_at;
+  private LocalDateTime updated_at;
+  private boolean rented;
+  private LocalDateTime rentDate;
+}

--- a/src/main/java/com/codeplanks/home360/domain/listingView/ListingView.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingView/ListingView.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.domain.listingView;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/codeplanks/home360/repository/CustomListingRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/CustomListingRepository.java
@@ -1,7 +1,9 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.listing.Listing;
+import com.codeplanks.home360.domain.listing.ListingWithViewCountDTO;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +12,8 @@ public interface CustomListingRepository {
       String city, int annualRent, String apartmentType, Pageable pageable);
 
   Page<Listing> findListingsByAgentId(Integer agentId, Pageable pageable);
+
+  ListingWithViewCountDTO findListingWithViewCountById(String listingId);
+
+  List<ListingWithViewCountDTO> getAllListingsWithViewCount();
 }

--- a/src/main/java/com/codeplanks/home360/repository/CustomListingRepositoryImpl.java
+++ b/src/main/java/com/codeplanks/home360/repository/CustomListingRepositoryImpl.java
@@ -1,14 +1,22 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.repository;
 
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+import static org.springframework.data.mongodb.core.aggregation.UnsetOperation.unset;
+
 import com.codeplanks.home360.domain.listing.Listing;
+import com.codeplanks.home360.domain.listing.ListingWithViewCountDTO;
+import com.codeplanks.home360.exception.NotFoundException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
+// import org.springframework.data.mongodb.core.aggregation.*;
+import org.springframework.data.mongodb.core.aggregation.*;
 import org.springframework.data.mongodb.core.query.Collation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -37,6 +45,46 @@ public class CustomListingRepositoryImpl implements CustomListingRepository {
     List<Listing> listings = mongoTemplate.find(query, Listing.class, "listings");
     return PageableExecutionUtils.getPage(
         listings, pageable, () -> mongoTemplate.count(query.limit(-1).skip(-1), Listing.class));
+  }
+
+  @Override
+  public ListingWithViewCountDTO findListingWithViewCountById(String listingId) {
+    Aggregation aggregation =
+        newAggregation(
+            match(Criteria.where("_id").is(new ObjectId(listingId))),
+            addFields()
+                .addFieldWithValue("listingIdStr", ConvertOperators.ToString.toString("$_id"))
+                .build(),
+            lookup("listingViews", "listingIdStr", "listingId", "views"),
+            addFields()
+                .addFieldWithValue("viewCount", ArrayOperators.Size.lengthOfArray("views"))
+                .build(),
+            unset("views", "listingIdStr"));
+
+    AggregationResults<ListingWithViewCountDTO> results =
+        mongoTemplate.aggregate(aggregation, "listings", ListingWithViewCountDTO.class);
+    return results.getMappedResults().stream()
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException("Listing not found"));
+  }
+
+  @Override
+  public List<ListingWithViewCountDTO> getAllListingsWithViewCount() {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            addFields()
+                .addFieldWithValue("listingIdStr", ConvertOperators.ToString.toString("$_id"))
+                .build(),
+            lookup("listingViews", "listingIdStr", "listingId", "views"),
+            addFields()
+                .addFieldWithValue("viewCount", ArrayOperators.Size.lengthOfArray("views"))
+                .build(),
+            unset("views"));
+
+    AggregationResults<ListingWithViewCountDTO> results =
+        mongoTemplate.aggregate(aggregation, "listings", ListingWithViewCountDTO.class);
+
+    return results.getMappedResults();
   }
 
   private Query fetchAgentListings(Integer agentId) {
@@ -70,4 +118,34 @@ public class CustomListingRepositoryImpl implements CustomListingRepository {
 
     return query;
   }
+
+  private MatchOperation matchAgentId(String agentId) {
+    return Aggregation.match(Criteria.where("agent_id").is(agentId));
+  }
+
+  private LookupOperation lookupListingViews() {
+    return Aggregation.lookup("listingViews", "_id", "listingId", "views");
+  }
+
+  private AddFieldsOperation addViewCount() {
+    return Aggregation.addFields()
+        .addFieldWithValue("viewCount", ArrayOperators.Size.lengthOfArray("views"))
+        .build();
+  }
+
+  private GroupOperation groupTotalViews() {
+    return Aggregation.group().sum("viewCount").as("total_views");
+  }
+
+  private UnwindOperation unwindViews() {
+    return Aggregation.unwind("views");
+  }
+
+  //  private GroupOperation groupViewsByYearAndMonth() {
+  //    return Aggregation.group()
+  //            .and("year($views.timestamp)").as("year")
+  //            .and("month($views.timestamp)").as("month")
+  //            .sum(1).as("total_views");
+  //  }
+
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listing.PaginatedResponse;
@@ -7,7 +7,6 @@ import com.codeplanks.home360.exception.NotFoundException;
 import com.codeplanks.home360.repository.ListingEnquiryRepository;
 import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.mongodb.client.result.UpdateResult;
-import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/codeplanks/home360/service/ListingService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingService.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listing.*;
@@ -18,7 +18,7 @@ public interface ListingService {
 
   ListingWithAgentInfo getListingById(String listingId);
 
-  List<Listing> allListings();
+  List<ListingWithViewCountDTO> allListings();
 
   PaginatedResponse<Listing> getListingsByAgentId(int page, int size);
 

--- a/src/main/java/com/codeplanks/home360/service/ListingServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingServiceImpl.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listing.*;
@@ -68,13 +68,13 @@ public class ListingServiceImpl implements ListingService {
             .build();
     Listing savedListing = listingRepository.save(listing);
 
-    logger.info("Listing created successfully: " + savedListing);
+    logger.info("Listing created successfully: {}", savedListing);
     return savedListing;
   }
 
   @Override
-  public List<Listing> allListings() {
-    return listingRepository.findAll();
+  public List<ListingWithViewCountDTO> allListings() {
+    return listingRepository.getAllListingsWithViewCount();
   }
 
   public Object deleteListing(String listingId) {
@@ -92,12 +92,16 @@ public class ListingServiceImpl implements ListingService {
 
   @Override
   public ListingWithAgentInfo getListingById(String listingId) {
-
-    Listing listing = findListingById(listingId);
-    int agentId = listing.getAgentId();
+    ListingWithViewCountDTO listing = getListingAndViewCountById(listingId);
+    int agentId = listing.getAgent_id();
     AppUser listingAgent = userService.getUserByUserId(agentId);
     ListingAgentInfo agentInfo = ListingMapper.mapToListingAgentInfo(listingAgent);
+
     return ListingWithAgentInfo.builder().agentInfo(agentInfo).listing(listing).build();
+  }
+
+  private ListingWithViewCountDTO getListingAndViewCountById(String listingId) {
+    return listingRepository.findListingWithViewCountById(listingId);
   }
 
   @Override
@@ -153,137 +157,408 @@ public class ListingServiceImpl implements ListingService {
       listingToUpdate.setRentDate(null);
     }
 
-    Listing savedListing = listingRepository.save(listingToUpdate);
-    logger.info("Listing rent status updated successfully: " + savedListing);
-
-    return savedListing;
+    return listingRepository.save(listingToUpdate);
   }
-  
+
   public Document getAggregateListingStats() {
     Integer userId = userService.extractUserId();
-    List<Document> pipeline = Arrays.asList(new Document("$match",
-                    new Document("agent_id", userId)),
-            new Document("$facet",
-                    new Document("totalListings", Arrays.asList(new Document("$count", "total_count")))
-                            .append("rentedListings", Arrays.asList(new Document("$match",
-                                            new Document("rented", true)),
-                                    new Document("$count", "total_rented")))
-                            .append("totalIncome", Arrays.asList(new Document("$match",
-                                            new Document("rented", true)),
-                                    new Document("$group",
-                                            new Document("_id",
-                                                    new BsonNull())
-                                                    .append("total_income",
-                                                            new Document("$sum",
-                                                                    new Document("$add", Arrays.asList("$cost.annual_rent", "$cost.agent_fee", "$cost.caution_fee", "$cost.agreement_fee")))))))
-                            .append("income", Arrays.asList(new Document("$match",
-                                            new Document("rented", true)),
-                                    new Document("$addFields",
-                                            new Document("total_income",
-                                                    new Document("$add", Arrays.asList("$cost.annual_rent", "$cost.agent_fee", "$cost.caution_fee", "$cost.agreement_fee")))),
-                                    new Document("$group",
-                                            new Document("_id",
-                                                    new Document("year",
-                                                            new Document("$year", "$created_at"))
-                                                            .append("month",
-                                                                    new Document("$month", "$created_at")))
-                                                    .append("total_income",
-                                                            new Document("$sum", "$total_income"))),
-                                    new Document("$group",
-                                            new Document("_id", "$_id.year")
-                                                    .append("months",
-                                                            new Document("$push",
-                                                                    new Document("k",
-                                                                            new Document("$arrayElemAt", Arrays.asList(Arrays.asList("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"),
-                                                                                    new Document("$subtract", Arrays.asList("$_id.month", 1L)))))
-                                                                            .append("v", "$total_income")))),
-                                    new Document("$addFields",
-                                            new Document("months",
-                                                    new Document("$mergeObjects", Arrays.asList(new Document("$arrayToObject",
-                                                                    new Document("$map",
-                                                                            new Document("input",
-                                                                                    new Document("$range", Arrays.asList(0L,
-                                                                                            new Document("$cond", Arrays.asList(new Document("$eq", Arrays.asList("$_id",
-                                                                                                            new Document("$year",
-                                                                                                                    new java.util.Date()))),
-                                                                                                    new Document("$month",
-                                                                                                            new java.util.Date()), 12L)))))
-                                                                                    .append("as", "i")
-                                                                                    .append("in",
-                                                                                            new Document("k",
-                                                                                                    new Document("$arrayElemAt", Arrays.asList(Arrays.asList("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"), "$$i")))
-                                                                                                    .append("v", 0L)))),
-                                                            new Document("$arrayToObject", "$months"))))),
-                                    new Document("$addFields",
-                                            new Document("months",
-                                                    new Document("$map",
-                                                            new Document("input",
-                                                                    new Document("$objectToArray", "$months"))
-                                                                    .append("as", "m")
-                                                                    .append("in",
-                                                                            new Document("name", "$$m.k")
-                                                                                    .append(
-                                                                                            "amount", "$$m.v"))))),
-                                    new Document("$project",
-                                            new Document("_id", 0L)
-                                                    .append("year", "$_id")
-                                                    .append("months", 1L))))
-                            .append("listings", Arrays.asList(new Document("$group",
-                                            new Document("_id",
-                                                    new Document("year",
-                                                            new Document("$year", "$created_at"))
-                                                            .append("month",
-                                                                    new Document("$month", "$created_at")))
-                                                    .append("count",
-                                                            new Document("$sum", 1L))),
-                                    new Document("$group",
-                                            new Document("_id", "$_id.year")
-                                                    .append("months",
-                                                            new Document("$push",
-                                                                    new Document("k",
-                                                                            new Document("$arrayElemAt", Arrays.asList(Arrays.asList("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"),
-                                                                                    new Document("$subtract", Arrays.asList("$_id.month", 1L)))))
-                                                                            .append("v", "$count")))),
-                                    new Document("$addFields",
-                                            new Document("months",
-                                                    new Document("$mergeObjects", Arrays.asList(new Document("$arrayToObject",
-                                                                    new Document("$map",
-                                                                            new Document("input",
-                                                                                    new Document("$range", Arrays.asList(0L,
-                                                                                            new Document("$cond", Arrays.asList(new Document("$eq", Arrays.asList("$_id",
-                                                                                                            new Document("$year",
-                                                                                                                    new java.util.Date()))),
-                                                                                                    new Document("$month",
-                                                                                                            new java.util.Date()), 12L)))))
-                                                                                    .append("as", "i")
-                                                                                    .append("in",
-                                                                                            new Document("k",
-                                                                                                    new Document("$arrayElemAt", Arrays.asList(Arrays.asList("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"), "$$i")))
-                                                                                                    .append("v", 0L)))),
-                                                            new Document("$arrayToObject", "$months"))))),
-                                    new Document("$addFields",
-                                            new Document("months",
-                                                    new Document("$map",
-                                                            new Document("input",
-                                                                    new Document("$objectToArray", "$months"))
-                                                                    .append("as", "m")
-                                                                    .append("in",
-                                                                            new Document("name", "$$m.k")
-                                                                                    .append(
-                                                                                            "amount", "$$m.v"))))),
-                                    new Document("$project",
-                                            new Document("_id", 0L)
-                                                    .append("year", "$_id")
-                                                    .append("months", 1L))))),
-            new Document("$project",
-                    new Document("total_listings",
-                            new Document("$arrayElemAt", Arrays.asList("$totalListings.total_count", 0L)))
-                            .append("rented_listings",
-                                    new Document("$arrayElemAt", Arrays.asList("$rentedListings.total_rented", 0L)))
-                            .append("total_income",
-                                    new Document("$arrayElemAt", Arrays.asList("$totalIncome.total_income", 0L)))
-                            .append("income", "$income")
-                            .append("listings", "$listings")));
+    List<Document> pipeline =
+        Arrays.asList(
+            new Document("$match", new Document("agent_id", userId)),
+            new Document(
+                "$addFields", new Document("listingIdStr", new Document("$toString", "$_id"))),
+            new Document(
+                "$facet",
+                new Document("totalListings", Arrays.asList(new Document("$count", "total_count")))
+                    .append(
+                        "rentedListings",
+                        Arrays.asList(
+                            new Document("$match", new Document("rented", true)),
+                            new Document("$count", "total_rented")))
+                    .append(
+                        "totalIncome",
+                        Arrays.asList(
+                            new Document("$match", new Document("rented", true)),
+                            new Document(
+                                "$group",
+                                new Document("_id", new BsonNull())
+                                    .append(
+                                        "total_income",
+                                        new Document(
+                                            "$sum",
+                                            new Document(
+                                                "$add",
+                                                Arrays.asList(
+                                                    "$cost.annual_rent",
+                                                    "$cost.agent_fee",
+                                                    "$cost.caution_fee",
+                                                    "$cost.agreement_fee")))))))
+                    .append(
+                        "income",
+                        Arrays.asList(
+                            new Document("$match", new Document("rented", true)),
+                            new Document(
+                                "$addFields",
+                                new Document(
+                                    "total_income",
+                                    new Document(
+                                        "$add",
+                                        Arrays.asList(
+                                            "$cost.annual_rent",
+                                            "$cost.agent_fee",
+                                            "$cost.caution_fee",
+                                            "$cost.agreement_fee")))),
+                            new Document(
+                                "$group",
+                                new Document(
+                                        "_id",
+                                        new Document("year", new Document("$year", "$created_at"))
+                                            .append("month", new Document("$month", "$created_at")))
+                                    .append("total_income", new Document("$sum", "$total_income"))),
+                            new Document(
+                                "$group",
+                                new Document("_id", "$_id.year")
+                                    .append(
+                                        "months",
+                                        new Document(
+                                            "$push",
+                                            new Document(
+                                                    "k",
+                                                    new Document(
+                                                        "$arrayElemAt",
+                                                        Arrays.asList(
+                                                            Arrays.asList(
+                                                                "January",
+                                                                "February",
+                                                                "March",
+                                                                "April",
+                                                                "May",
+                                                                "June",
+                                                                "July",
+                                                                "August",
+                                                                "September",
+                                                                "October",
+                                                                "November",
+                                                                "December"),
+                                                            new Document(
+                                                                "$subtract",
+                                                                Arrays.asList("$_id.month", 1L)))))
+                                                .append("v", "$total_income")))),
+                            new Document(
+                                "$addFields",
+                                new Document(
+                                    "months",
+                                    new Document(
+                                        "$mergeObjects",
+                                        Arrays.asList(
+                                            new Document(
+                                                "$arrayToObject",
+                                                new Document(
+                                                    "$map",
+                                                    new Document(
+                                                            "input",
+                                                            new Document(
+                                                                "$range", Arrays.asList(0L, 12L)))
+                                                        .append("as", "i")
+                                                        .append(
+                                                            "in",
+                                                            new Document(
+                                                                    "k",
+                                                                    new Document(
+                                                                        "$arrayElemAt",
+                                                                        Arrays.asList(
+                                                                            Arrays.asList(
+                                                                                "January",
+                                                                                "February",
+                                                                                "March",
+                                                                                "April",
+                                                                                "May",
+                                                                                "June",
+                                                                                "July",
+                                                                                "August",
+                                                                                "September",
+                                                                                "October",
+                                                                                "November",
+                                                                                "December"),
+                                                                            "$$i")))
+                                                                .append("v", 0L)))),
+                                            new Document("$arrayToObject", "$months"))))),
+                            new Document(
+                                "$addFields",
+                                new Document(
+                                    "months",
+                                    new Document(
+                                        "$map",
+                                        new Document(
+                                                "input", new Document("$objectToArray", "$months"))
+                                            .append("as", "m")
+                                            .append(
+                                                "in",
+                                                new Document("name", "$$m.k")
+                                                    .append("amount", "$$m.v"))))),
+                            new Document(
+                                "$project",
+                                new Document("_id", 0L)
+                                    .append("year", "$_id")
+                                    .append("months", 1L))))
+                    .append(
+                        "listings",
+                        Arrays.asList(
+                            new Document(
+                                "$group",
+                                new Document(
+                                        "_id",
+                                        new Document("year", new Document("$year", "$created_at"))
+                                            .append("month", new Document("$month", "$created_at")))
+                                    .append("count", new Document("$sum", 1L))),
+                            new Document(
+                                "$group",
+                                new Document("_id", "$_id.year")
+                                    .append(
+                                        "months",
+                                        new Document(
+                                            "$push",
+                                            new Document(
+                                                    "k",
+                                                    new Document(
+                                                        "$arrayElemAt",
+                                                        Arrays.asList(
+                                                            Arrays.asList(
+                                                                "January",
+                                                                "February",
+                                                                "March",
+                                                                "April",
+                                                                "May",
+                                                                "June",
+                                                                "July",
+                                                                "August",
+                                                                "September",
+                                                                "October",
+                                                                "November",
+                                                                "December"),
+                                                            new Document(
+                                                                "$subtract",
+                                                                Arrays.asList("$_id.month", 1L)))))
+                                                .append("v", "$count")))),
+                            new Document(
+                                "$addFields",
+                                new Document(
+                                    "months",
+                                    new Document(
+                                        "$mergeObjects",
+                                        Arrays.asList(
+                                            new Document(
+                                                "$arrayToObject",
+                                                new Document(
+                                                    "$map",
+                                                    new Document(
+                                                            "input",
+                                                            new Document(
+                                                                "$range", Arrays.asList(0L, 12L)))
+                                                        .append("as", "i")
+                                                        .append(
+                                                            "in",
+                                                            new Document(
+                                                                    "k",
+                                                                    new Document(
+                                                                        "$arrayElemAt",
+                                                                        Arrays.asList(
+                                                                            Arrays.asList(
+                                                                                "January",
+                                                                                "February",
+                                                                                "March",
+                                                                                "April",
+                                                                                "May",
+                                                                                "June",
+                                                                                "July",
+                                                                                "August",
+                                                                                "September",
+                                                                                "October",
+                                                                                "November",
+                                                                                "December"),
+                                                                            "$$i")))
+                                                                .append("v", 0L)))),
+                                            new Document("$arrayToObject", "$months"))))),
+                            new Document(
+                                "$addFields",
+                                new Document(
+                                    "months",
+                                    new Document(
+                                        "$map",
+                                        new Document(
+                                                "input", new Document("$objectToArray", "$months"))
+                                            .append("as", "m")
+                                            .append(
+                                                "in",
+                                                new Document("name", "$$m.k")
+                                                    .append("amount", "$$m.v"))))),
+                            new Document(
+                                "$project",
+                                new Document("_id", 0L)
+                                    .append("year", "$_id")
+                                    .append("months", 1L))))
+                    .append(
+                        "totalViews",
+                        Arrays.asList(
+                            new Document(
+                                "$lookup",
+                                new Document("from", "listingViews")
+                                    .append("localField", "listingIdStr")
+                                    .append("foreignField", "listingId")
+                                    .append("as", "views")),
+                            new Document(
+                                "$addFields",
+                                new Document("viewCount", new Document("$size", "$views"))),
+                            new Document(
+                                "$group",
+                                new Document("_id", new BsonNull())
+                                    .append("total_views", new Document("$sum", "$viewCount")))))
+                    .append(
+                        "viewsByYearAndMonth",
+                        Arrays.asList(
+                            new Document(
+                                "$lookup",
+                                new Document("from", "listingViews")
+                                    .append("localField", "listingIdStr")
+                                    .append("foreignField", "listingId")
+                                    .append("as", "views")),
+                            new Document("$unwind", "$views"),
+                            new Document(
+                                "$group",
+                                new Document(
+                                        "_id",
+                                        new Document(
+                                                "year", new Document("$year", "$views.timestamp"))
+                                            .append(
+                                                "month",
+                                                new Document("$month", "$views.timestamp")))
+                                    .append("total_views", new Document("$sum", 1L))),
+                            new Document(
+                                "$group",
+                                new Document("_id", "$_id.year")
+                                    .append(
+                                        "months",
+                                        new Document(
+                                            "$push",
+                                            new Document(
+                                                    "k",
+                                                    new Document(
+                                                        "$arrayElemAt",
+                                                        Arrays.asList(
+                                                            Arrays.asList(
+                                                                "January",
+                                                                "February",
+                                                                "March",
+                                                                "April",
+                                                                "May",
+                                                                "June",
+                                                                "July",
+                                                                "August",
+                                                                "September",
+                                                                "October",
+                                                                "November",
+                                                                "December"),
+                                                            new Document(
+                                                                "$subtract",
+                                                                Arrays.asList("$_id.month", 1L)))))
+                                                .append("v", "$total_views")))),
+                            new Document(
+                                "$addFields",
+                                new Document(
+                                    "months",
+                                    new Document(
+                                        "$mergeObjects",
+                                        Arrays.asList(
+                                            new Document(
+                                                "$arrayToObject",
+                                                new Document(
+                                                    "$map",
+                                                    new Document(
+                                                            "input",
+                                                            new Document(
+                                                                "$range", Arrays.asList(0L, 12L)))
+                                                        .append("as", "i")
+                                                        .append(
+                                                            "in",
+                                                            new Document(
+                                                                    "k",
+                                                                    new Document(
+                                                                        "$arrayElemAt",
+                                                                        Arrays.asList(
+                                                                            Arrays.asList(
+                                                                                "January",
+                                                                                "February",
+                                                                                "March",
+                                                                                "April",
+                                                                                "May",
+                                                                                "June",
+                                                                                "July",
+                                                                                "August",
+                                                                                "September",
+                                                                                "October",
+                                                                                "November",
+                                                                                "December"),
+                                                                            "$$i")))
+                                                                .append("v", 0L)))),
+                                            new Document("$arrayToObject", "$months"))))),
+                            new Document(
+                                "$addFields",
+                                new Document(
+                                    "months",
+                                    new Document(
+                                        "$map",
+                                        new Document(
+                                                "input", new Document("$objectToArray", "$months"))
+                                            .append("as", "m")
+                                            .append(
+                                                "in",
+                                                new Document("name", "$$m.k")
+                                                    .append("views", "$$m.v"))))),
+                            new Document(
+                                "$project",
+                                new Document("_id", 0L)
+                                    .append("year", "$_id")
+                                    .append("months", 1L))))
+                    .append(
+                        "topListingsByViews",
+                        Arrays.asList(
+                            new Document(
+                                "$lookup",
+                                new Document("from", "listingViews")
+                                    .append("localField", "listingIdStr")
+                                    .append("foreignField", "listingId")
+                                    .append("as", "views")),
+                            new Document(
+                                "$addFields",
+                                new Document("viewCount", new Document("$size", "$views"))),
+                            new Document("$sort", new Document("viewCount", -1L)),
+                            new Document("$limit", 10L),
+                            new Document(
+                                "$project",
+                                new Document("listingId", 1L)
+                                    .append("title", 1L)
+                                    .append("viewCount", 1L))))),
+            new Document(
+                "$project",
+                new Document(
+                        "total_listings",
+                        new Document(
+                            "$arrayElemAt", Arrays.asList("$totalListings.total_count", 0L)))
+                    .append(
+                        "rented_listings",
+                        new Document(
+                            "$arrayElemAt", Arrays.asList("$rentedListings.total_rented", 0L)))
+                    .append(
+                        "total_income",
+                        new Document(
+                            "$arrayElemAt", Arrays.asList("$totalIncome.total_income", 0L)))
+                    .append("income", "$income")
+                    .append("listings", "$listings")
+                    .append(
+                        "total_views",
+                        new Document("$arrayElemAt", Arrays.asList("$totalViews.total_views", 0L)))
+                    .append("views_by_year_and_month", "$viewsByYearAndMonth")
+                    .append("mostViewedListings", "$topListingsByViews")));
 
     return mongoTemplate.getDb().getCollection("listings").aggregate(pipeline).first();
   }

--- a/src/main/java/com/codeplanks/home360/service/ListingViewServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingViewServiceImpl.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listing.Listing;
@@ -10,6 +10,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +27,7 @@ public class ListingViewServiceImpl implements ListingViewService {
     ZonedDateTime utcTimestamp = request.getTimestamp().atZone(ZoneId.of("UTC"));
     LocalDateTime localTimestamp =
         utcTimestamp.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+    ObjectId listingObjectId = new ObjectId(request.getListingId());
     ListingView listingView =
         ListingView.builder()
             .listingId(request.getListingId())

--- a/src/test/java/com/codeplanks/home360/repository/CustomListingRepositoryTest.java
+++ b/src/test/java/com/codeplanks/home360/repository/CustomListingRepositoryTest.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import com.codeplanks.home360.domain.listing.Listing;
 import java.util.List;
 import org.bson.Document;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -32,9 +31,6 @@ class CustomListingRepositoryTest {
   @Mock private MongoTemplate mongoTemplate;
 
   @Mock private Pageable pageable;
-
-  @BeforeEach
-  void setUp() {}
 
   @Test
   void findAllWithFilter() {
@@ -97,5 +93,14 @@ class CustomListingRepositoryTest {
 
     assertThat(capturedQuery.getQueryObject().get("agentId")).isEqualTo(agentId);
     assertThat(capturedQuery.getSortObject().get("created_at")).isEqualTo(-1);
+  }
+
+  @Test
+  void findListingWithViewCountById() {
+    // Given
+
+    // When
+
+    // Then
   }
 }

--- a/src/test/java/com/codeplanks/home360/service/ListingServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingServiceTest.java
@@ -157,11 +157,11 @@ class ListingServiceTest {
   @DisplayName("Get all listings")
   void givenListingsExistWhenAllListingsThenReturnListOfListings() {
     // Given
-    Listing listing1 = new Listing();
-    Listing listing2 = new Listing();
-    List<Listing> listings = Arrays.asList(listing1, listing2);
+    ListingWithViewCountDTO listing1 = new ListingWithViewCountDTO();
+    ListingWithViewCountDTO listing2 = new ListingWithViewCountDTO();
+    List<ListingWithViewCountDTO> listings = Arrays.asList(listing1, listing2);
 
-    given(listingRepository.findAll()).willReturn(listings);
+    given(listingRepository.getAllListingsWithViewCount()).willReturn(listings);
 
     // When
     List<ListingWithViewCountDTO> result = listingService.allListings();
@@ -169,14 +169,14 @@ class ListingServiceTest {
     // Assert
     assertNotNull(result);
     assertEquals(2, result.size());
-    verify(listingRepository, times(1)).findAll();
+    verify(listingRepository, times(1)).getAllListingsWithViewCount();
   }
 
   @Test
   @DisplayName("Empty listings")
   void givenNoListingsExistWhenAllListingsThenReturnEmptyList() {
     // Given
-    given(listingRepository.findAll()).willReturn(Collections.emptyList());
+    given(listingRepository.getAllListingsWithViewCount()).willReturn(Collections.emptyList());
 
     // When
     List<ListingWithViewCountDTO> result = listingService.allListings();
@@ -184,7 +184,7 @@ class ListingServiceTest {
     // Then
     assertNotNull(result);
     assertTrue(result.isEmpty());
-    verify(listingRepository, times(1)).findAll();
+    verify(listingRepository, times(1)).getAllListingsWithViewCount();
   }
 
   @Test
@@ -253,13 +253,22 @@ class ListingServiceTest {
   void givenValidListingIdWhenRequestForListingThenReturnListingWithAgentInfo() {
     // Given
     Integer userId = 1;
+
     String listingId = "12345";
     Listing listing = new Listing();
+
+    ListingWithViewCountDTO listingWithViewCountDTO = new ListingWithViewCountDTO();
+    listingWithViewCountDTO.setId(listingId);
+    listingWithViewCountDTO.setAgent_id(userId);
+
     listing.setId(listingId);
     listing.setAgentId(userId);
     AppUser user = new AppUser();
     user.setId(userId);
-    given(listingRepository.findById(listingId)).willReturn(Optional.of(listing));
+
+    given(listingRepository.findListingWithViewCountById(listingId))
+        .willReturn(listingWithViewCountDTO);
+
     given(userService.getUserByUserId(userId)).willReturn(user);
 
     // When
@@ -268,7 +277,7 @@ class ListingServiceTest {
     // Then
     assertNotNull(result);
     assertEquals(1, result.getListing().getAgent_id());
-    verify(listingRepository, times(1)).findById(listingId);
+    verify(listingRepository, times(1)).findListingWithViewCountById(listingId);
   }
 
   @Test
@@ -276,7 +285,9 @@ class ListingServiceTest {
   void givenNonExistentListingIdWhenUserRequestForListingThenThrowNotFoundExceptions() {
     // Given
     String listingId = "1234";
-    given(listingRepository.findById(listingId)).willReturn(Optional.empty());
+    given(listingRepository.findListingWithViewCountById(listingId))
+        .willThrow(new NotFoundException("Listing not found"));
+
     // When
     NotFoundException exception =
         assertThrows(NotFoundException.class, () -> listingService.getListingById(listingId));

--- a/src/test/java/com/codeplanks/home360/service/ListingServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingServiceTest.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -164,7 +164,7 @@ class ListingServiceTest {
     given(listingRepository.findAll()).willReturn(listings);
 
     // When
-    List<Listing> result = listingService.allListings();
+    List<ListingWithViewCountDTO> result = listingService.allListings();
 
     // Assert
     assertNotNull(result);
@@ -179,7 +179,7 @@ class ListingServiceTest {
     given(listingRepository.findAll()).willReturn(Collections.emptyList());
 
     // When
-    List<Listing> result = listingService.allListings();
+    List<ListingWithViewCountDTO> result = listingService.allListings();
 
     // Then
     assertNotNull(result);
@@ -267,7 +267,7 @@ class ListingServiceTest {
 
     // Then
     assertNotNull(result);
-    assertEquals(1, result.getListing().getAgentId());
+    assertEquals(1, result.getListing().getAgent_id());
     verify(listingRepository, times(1)).findById(listingId);
   }
 

--- a/src/test/java/com/codeplanks/home360/service/ListingViewServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingViewServiceTest.java
@@ -63,7 +63,7 @@ class ListingViewServiceTest {
             .build();
     ListingView listingView =
         ListingView.builder()
-            .listingId(listingObjectId)
+            .listingId(listingId)
             .timestamp(LocalDateTime.now())
             .createdAt(LocalDateTime.now())
             .build();
@@ -75,7 +75,7 @@ class ListingViewServiceTest {
         () -> assertThat(result).isNotNull(),
         () -> {
           assert result != null;
-          assertThat(result.getListingId()).isEqualTo(new ObjectId("663b268e5512f1692718c3ec"));
+          assertThat(result.getListingId()).isEqualTo("663b268e5512f1692718c3ec");
         },
         () -> assertThat(result.getTimestamp()).isNotNull(),
         () -> assertThat(result.getTimestamp()).isInstanceOf(LocalDateTime.class));

--- a/src/test/java/com/codeplanks/home360/service/ListingViewServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingViewServiceTest.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,8 +50,11 @@ class ListingViewServiceTest {
   @DisplayName("save listing view")
   void givenValidListingViewRequestWhenSavedThenNewListingViewIsCreated() {
     // Given
+    String listingId = "663b268e5512f1692718c3ec";
     Listing listing = new Listing();
-    listing.setId("663b268e5512f1692718c3ec");
+    listing.setId(listingId);
+    ObjectId listingObjectId = new ObjectId(listing.getId());
+
     ListingViewDTO request =
         ListingViewDTO.builder()
             .listingId(listing.getId())
@@ -59,7 +63,7 @@ class ListingViewServiceTest {
             .build();
     ListingView listingView =
         ListingView.builder()
-            .listingId(listing.getId())
+            .listingId(listingObjectId)
             .timestamp(LocalDateTime.now())
             .createdAt(LocalDateTime.now())
             .build();
@@ -71,7 +75,7 @@ class ListingViewServiceTest {
         () -> assertThat(result).isNotNull(),
         () -> {
           assert result != null;
-          assertThat(result.getListingId()).isEqualTo("663b268e5512f1692718c3ec");
+          assertThat(result.getListingId()).isEqualTo(new ObjectId("663b268e5512f1692718c3ec"));
         },
         () -> assertThat(result.getTimestamp()).isNotNull(),
         () -> assertThat(result.getTimestamp()).isInstanceOf(LocalDateTime.class));


### PR DESCRIPTION
## What does this PR do?
* Get  listing views count

## Description of tasks to be completed
* Add total view count of each listing to it.
* To listing statistics, add the following
- [x] Total views count
- [x] View count by month and year
- [x] 10 most viewed listings

## How can this be manually tested?
* Clone the repository
* Open a terminal and `cd` to the project directory
* Install dependencies
* Run the project
* Send a `GET` request to `http://localhost:8080/api/v1/listings/${listingId}` and look for a `viewCount` field in the response.
* Send a `GET` request to `http://localhost:8080/api/v1/listings/listing-statistics` and look out for the followin fields

1. total_views
2. views_by_year_and_month
3. mostViewedListings


## What are the relevant Jira board stories?
[HOM-154](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-154)


[HOM-154]: https://wasiu-dev.atlassian.net/browse/HOM-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ