### PR TITLE
bug:fix listing monthly income calculation error  (HOM-156)

### DIFF
--- a/src/main/java/com/codeplanks/home360/domain/auth/AuthenticationResponse.java
+++ b/src/main/java/com/codeplanks/home360/domain/auth/AuthenticationResponse.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.domain.auth;
 
 import com.codeplanks.home360.domain.token.TokenResponse;
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AuthenticationResponse {
+  private Integer id;
   private String firstName;
   private String lastName;
   private TokenResponse token;

--- a/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.config.JwtService;
@@ -109,6 +109,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
               .build();
       return AuthenticationResponse.builder()
           .token(tokenResponse)
+          .id(user.getId())
           .firstName(user.getFirstName())
           .lastName(user.getLastName())
           .build();

--- a/src/main/java/com/codeplanks/home360/service/ListingServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingServiceImpl.java
@@ -164,7 +164,7 @@ public class ListingServiceImpl implements ListingService {
     Integer userId = userService.extractUserId();
     List<Document> pipeline =
         Arrays.asList(
-            new Document("$match", new Document("agent_id", userId)),
+            new Document("$match", new Document("agent_id", 1L)),
             new Document(
                 "$addFields", new Document("listingIdStr", new Document("$toString", "$_id"))),
             new Document(
@@ -212,8 +212,8 @@ public class ListingServiceImpl implements ListingService {
                                 "$group",
                                 new Document(
                                         "_id",
-                                        new Document("year", new Document("$year", "$created_at"))
-                                            .append("month", new Document("$month", "$created_at")))
+                                        new Document("year", new Document("$year", "$rentDate"))
+                                            .append("month", new Document("$month", "$rentDate")))
                                     .append("total_income", new Document("$sum", "$total_income"))),
                             new Document(
                                 "$group",
@@ -300,7 +300,8 @@ public class ListingServiceImpl implements ListingService {
                                 "$project",
                                 new Document("_id", 0L)
                                     .append("year", "$_id")
-                                    .append("months", 1L))))
+                                    .append("months", 1L)),
+                            new Document("$sort", new Document("year", 1L))))
                     .append(
                         "listings",
                         Arrays.asList(
@@ -396,7 +397,8 @@ public class ListingServiceImpl implements ListingService {
                                 "$project",
                                 new Document("_id", 0L)
                                     .append("year", "$_id")
-                                    .append("months", 1L))))
+                                    .append("months", 1L)),
+                            new Document("$sort", new Document("year", 1L))))
                     .append(
                         "totalViews",
                         Arrays.asList(
@@ -532,12 +534,8 @@ public class ListingServiceImpl implements ListingService {
                                 "$addFields",
                                 new Document("viewCount", new Document("$size", "$views"))),
                             new Document("$sort", new Document("viewCount", -1L)),
-                            new Document("$limit", 10L),
-                            new Document(
-                                "$project",
-                                new Document("listingId", 1L)
-                                    .append("title", 1L)
-                                    .append("viewCount", 1L))))),
+                            new Document("$limit", 5L),
+                            new Document("$unset", Arrays.asList("views", "_class"))))),
             new Document(
                 "$project",
                 new Document(


### PR DESCRIPTION
## What does this PR do?
* Fixes the error in monthly income calculation


## Description of task to be completed
* Modify aggregation pipeline for calculating income

##  How can this be manually tested?
* Clone the repository
* Open a terminal and `cd` to the project directory
* Install dependencies
* Run the project
* Send a `GET` request to `http://localhost:8080/api/v1/listings/listing-statistics`  and take a look at the income field
```
curl --location 'http://localhost:8080/api/v1/listings/listing-statistics' \
--header 'Authorization: Bearer ${token}'
```

## What are the relevant Jira board stories?
[HOM-156](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-156)

[HOM-156]: https://wasiu-dev.atlassian.net/browse/HOM-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ