### PR TITLE
feat: implement logout on server (HOM-168)

### DIFF
--- a/src/main/java/com/codeplanks/home360/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeplanks/home360/config/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 /* (C)2024-2025 */
 package com.codeplanks.home360.config;
 
+import com.codeplanks.home360.utils.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
@@ -27,6 +28,8 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Autowired private final JwtService jwtService;
+  @Autowired private JwtUtils jwtUtils;
+
   private final UserDetailsService userDetailsService;
   Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
@@ -57,19 +60,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     try {
       jwt = authHeader.substring(7);
-      username = jwtService.extractUsername(jwt);
-      if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-        UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
-        if (jwtService.isTokenValid(jwt, userDetails)) {
-          UsernamePasswordAuthenticationToken authenticationToken =
-              new UsernamePasswordAuthenticationToken(
-                  userDetails, null, userDetails.getAuthorities());
-          authenticationToken.setDetails(
-              new WebAuthenticationDetailsSource().buildDetails(request));
-          SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+      if (jwtUtils.validateToken(jwt)) {
+        username = jwtService.extractUsername(jwt);
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+          UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+          if (jwtService.isTokenValid(jwt, userDetails)) {
+            UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+            authenticationToken.setDetails(
+                new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+          }
         }
       }
-
     } catch (ExpiredJwtException | MalformedJwtException | IllegalArgumentException exception) {
       logger.error("JWT Error: {}", exception.getMessage());
       resolver.resolveException(request, response, null, exception);

--- a/src/main/java/com/codeplanks/home360/config/JwtService.java
+++ b/src/main/java/com/codeplanks/home360/config/JwtService.java
@@ -1,19 +1,18 @@
+/* (C)2025 */
 package com.codeplanks.home360.config;
 
+import com.codeplanks.home360.utils.JwtUtils;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Service;
-
-import java.security.Key;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
 
 @Service
 public class JwtService {
@@ -24,44 +23,34 @@ public class JwtService {
   @Value("${application.security.jwt.jwtTokenExpirationMs}")
   private int jwtExpiration;
 
+  @Autowired private JwtUtils jwtUtils;
+
   public String extractUsername(String jwtToken) {
     return extractClaim(jwtToken, Claims::getSubject);
   }
 
   public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
-    final Claims claims = extractAllClaims(token);
+    final Claims claims = jwtUtils.extractAllClaims(token);
     return claimsResolver.apply(claims);
-  }
-
-  private Claims extractAllClaims(String token) {
-    return Jwts.parserBuilder()
-            .setSigningKey(getSigninKey())
-            .build()
-            .parseClaimsJws(token)
-            .getBody();
-  }
-
-  private Key getSigninKey() {
-    byte[] keyBytes = Decoders.BASE64.decode(secretKey);
-    return Keys.hmacShaKeyFor((keyBytes));
   }
 
   /**
    * generate token from just user details
-   */
+   *
+   * @param userDetails  The details of the user
+   * */
   public String generateToken(UserDetails userDetails) {
     return generateToken(new HashMap<>(), userDetails);
   }
 
   public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
-    return Jwts
-            .builder()
-            .setClaims(extraClaims)
-            .setSubject(userDetails.getUsername())
-            .setIssuedAt(new Date())
-            .setExpiration(new Date((new Date()).getTime() + jwtExpiration))
-            .signWith(getSigninKey(), SignatureAlgorithm.HS512)
-            .compact();
+    return Jwts.builder()
+        .setClaims(extraClaims)
+        .setSubject(userDetails.getUsername())
+        .setIssuedAt(new Date())
+        .setExpiration(new Date((new Date()).getTime() + jwtExpiration))
+        .signWith(jwtUtils.getSigninKey(), SignatureAlgorithm.HS512)
+        .compact();
   }
 
   public boolean isTokenValid(String token, UserDetails userDetails) {
@@ -75,7 +64,6 @@ public class JwtService {
     } catch (RuntimeException exception) {
       throw new RuntimeException(exception.getMessage(), exception);
     }
-
   }
 
   private Date extractExpiration(String token) {

--- a/src/main/java/com/codeplanks/home360/controller/AuthenticationController.java
+++ b/src/main/java/com/codeplanks/home360/controller/AuthenticationController.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.controller;
 
 import com.codeplanks.home360.domain.auth.*;
@@ -124,6 +124,42 @@ public class AuthenticationController {
     result.setData(authResponse);
     result.setMessage("Login successful");
     result.setStatus(HttpStatus.OK);
+
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
+  @Operation(
+      summary = "Log user out",
+      description = "Sign a user out of the application",
+      tags = {"POST"})
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "Logout successful",
+        content = {
+          @Content(schema = @Schema(implementation = String.class), mediaType = "application/json")
+        }),
+    @ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized",
+        content = {
+          @Content(
+              schema = @Schema(implementation = ApiError.class),
+              mediaType = "application/json")
+        }),
+  })
+  @PostMapping("/logout")
+  public ResponseEntity<SuccessDataResponse<String>> logout(
+      @RequestHeader("Authorization") String authToken,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    String token = authToken.substring(7);
+
+    SuccessDataResponse<String> result = new SuccessDataResponse<>();
+
+    result.setData(authenticationServiceImpl.logout(token, request, response));
+    result.setStatus(HttpStatus.OK);
+    result.setMessage("Logout successful");
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/src/main/java/com/codeplanks/home360/domain/auth/BlacklistedToken.java
+++ b/src/main/java/com/codeplanks/home360/domain/auth/BlacklistedToken.java
@@ -1,0 +1,37 @@
+/* (C)2025 */
+package com.codeplanks.home360.domain.auth;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity(name = "blacklisted_tokens")
+@Table(name = "blacklisted_tokens")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlacklistedToken {
+
+  @Id
+  @SequenceGenerator(
+      name = "blacklisted_tokens_id_sequence",
+      sequenceName = "blacklisted_tokens_id_sequence",
+      allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "blacklisted_tokens_id_sequence")
+  private Long id;
+
+  private String token;
+  private LocalDateTime expiryDate;
+
+  @Column(
+      name = "createdAt",
+      nullable = false,
+      columnDefinition = "TIMESTAMP WITH TIME ZONE DEFAULT NOW()")
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/codeplanks/home360/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/BlacklistedTokenRepository.java
@@ -1,0 +1,11 @@
+/* (C)2025 */
+package com.codeplanks.home360.repository;
+
+import com.codeplanks.home360.domain.auth.BlacklistedToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
+  boolean existsByToken(String token);
+}

--- a/src/main/java/com/codeplanks/home360/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/RefreshTokenRepository.java
@@ -1,14 +1,15 @@
+/* (C)2025 */
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.refreshToken.RefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * @author Wasiu Idowu
- * */
-
+ */
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
   Optional<RefreshToken> findByToken(String token);
+
+  void deleteByToken(String token);
 }

--- a/src/main/java/com/codeplanks/home360/service/AuthenticationService.java
+++ b/src/main/java/com/codeplanks/home360/service/AuthenticationService.java
@@ -1,9 +1,11 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.auth.*;
 import com.codeplanks.home360.domain.user.AppUser;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 
 /**
@@ -22,4 +24,6 @@ public interface AuthenticationService {
 
   String requestPasswordReset(PasswordResetRequestDTO request)
       throws MessagingException, UnsupportedEncodingException;
+
+  String logout(String token, HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
@@ -12,9 +12,13 @@ import com.codeplanks.home360.event.RegistrationCompleteEvent;
 import com.codeplanks.home360.event.listener.RegistrationCompleteEventListener;
 import com.codeplanks.home360.exception.NotFoundException;
 import com.codeplanks.home360.exception.UserAlreadyExistsException;
+import com.codeplanks.home360.repository.RefreshTokenRepository;
 import com.codeplanks.home360.repository.UserRepository;
+import com.codeplanks.home360.utils.JwtUtils;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +38,6 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Wasiu Idowu
  */
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class AuthenticationServiceImpl implements AuthenticationService {
   final HttpServletRequest servletRequest;
@@ -48,6 +51,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
   private final RegistrationCompleteEventListener eventListener;
   private final ApplicationEventPublisher publisher;
   private final VerificationTokenServiceImpl verificationTokenService;
+  private final JwtUtils jwtUtils;
   Logger logger = LoggerFactory.getLogger(AuthenticationServiceImpl.class);
 
   @Value("${application.frontend.reset-password.url}")
@@ -56,11 +60,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
   @Value("${application.frontend.verify-email.url}")
   private String emailVerificationUrl;
 
+  private final RefreshTokenRepository refreshTokenRepository;
+
   @Override
   public AppUser register(RegisterRequest request) throws UserAlreadyExistsException {
-    if (userService.userExists(request.getEmail().toLowerCase(), request.getPhoneNumber())){
-      throw new UserAlreadyExistsException(
-              "User with email or phone number already exists");
+    if (userService.userExists(request.getEmail().toLowerCase(), request.getPhoneNumber())) {
+      throw new UserAlreadyExistsException("User with email or phone number already exists");
     }
 
     AppUser user =
@@ -156,6 +161,24 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     return passwordResetTokenServiceImpl
         .findUserByPasswordToken(token)
         .orElseThrow(() -> new NotFoundException("Invalid password reset token"));
+  }
+
+  @Transactional
+  @Override
+  public String logout(String token, HttpServletRequest request, HttpServletResponse response) {
+    jwtUtils.invalidateToken(token);
+
+    String refreshToken = jwtUtils.extractRefreshTokenFromRequest(request);
+    if (refreshToken != null) {
+      refreshTokenRepository.deleteByToken(refreshToken);
+    }
+    Cookie cookie = new Cookie("refreshToken", null);
+    cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+
+    return "User successfully logged out";
   }
 
   private void createPasswordResetTokenForUser(AppUser user, String passwordResetToken) {

--- a/src/main/java/com/codeplanks/home360/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/RefreshTokenServiceImpl.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.config.JwtService;
@@ -54,14 +54,14 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     if (refreshToken.getExpiryDate().isBefore(LocalDateTime.now())) {
       refreshTokenRepository.delete(refreshToken);
       throw new ExpiredTokenException(
-          refreshToken.getToken() + "Refresh token has expired, make a new" + " login request");
+          refreshToken.getToken() + "Refresh token has expired, make a new login request");
     }
     return refreshToken;
   }
 
   private RefreshToken getRefreshToken(String token) {
     return findByToken(token)
-        .orElseThrow(() -> new NotFoundException("Refresh token not in " + "database"));
+        .orElseThrow(() -> new NotFoundException("Refresh token not in database"));
   }
 
   private AppUser getUserIfRefreshTokenValid(RefreshToken refreshToken) {

--- a/src/main/java/com/codeplanks/home360/utils/JwtUtils.java
+++ b/src/main/java/com/codeplanks/home360/utils/JwtUtils.java
@@ -1,0 +1,83 @@
+/* (C)2025 */
+package com.codeplanks.home360.utils;
+
+import com.codeplanks.home360.domain.auth.BlacklistedToken;
+import com.codeplanks.home360.repository.BlacklistedTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtils {
+  private final BlacklistedTokenRepository blacklistedTokenRepository;
+
+  @Value("${application.security.jwt.secret-key}")
+  private String secretKey;
+
+  @Autowired
+  public JwtUtils(BlacklistedTokenRepository blacklistedTokenRepository) {
+    this.blacklistedTokenRepository = blacklistedTokenRepository;
+  }
+
+  public void invalidateToken(String token) {
+    LocalDateTime expiryDate = extractExpiryDate(token);
+
+    BlacklistedToken blacklistedToken = new BlacklistedToken();
+    blacklistedToken.setToken(token);
+    blacklistedToken.setExpiryDate(expiryDate);
+
+    blacklistedTokenRepository.save(blacklistedToken);
+  }
+
+  public Claims extractAllClaims(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(getSigninKey())
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+  }
+
+  public Key getSigninKey() {
+    byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+    return Keys.hmacShaKeyFor((keyBytes));
+  }
+
+  public boolean validateToken(String token) {
+    if (blacklistedTokenRepository.existsByToken(token)) {
+      return false;
+    }
+    try {
+      Jwts.parserBuilder().setSigningKey(getSigninKey()).build().parseClaimsJws(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException exception) {
+      return false;
+    }
+  }
+
+  public LocalDateTime extractExpiryDate(String token) {
+    Claims claims = extractAllClaims(token);
+    return claims.getExpiration().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+  }
+
+  public String extractRefreshTokenFromRequest(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if ("refreshToken".equals(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2025 */
 package com.codeplanks.home360.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -16,11 +16,12 @@ import com.codeplanks.home360.domain.verificationToken.VerificationToken;
 import com.codeplanks.home360.event.listener.RegistrationCompleteEventListener;
 import com.codeplanks.home360.exception.NotFoundException;
 import com.codeplanks.home360.exception.UserAlreadyExistsException;
-import com.codeplanks.home360.repository.PasswordResetTokenRepository;
-import com.codeplanks.home360.repository.UserRepository;
-import com.codeplanks.home360.repository.VerificationTokenRepository;
+import com.codeplanks.home360.repository.*;
+import com.codeplanks.home360.utils.JwtUtils;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -59,6 +61,11 @@ class AuthenticationServiceTest {
   @Mock private RegistrationCompleteEventListener eventListener;
   @Mock private HttpServletRequest servletRequest;
   @Mock private ApplicationEventPublisher publisher;
+  @Mock private JwtUtils jwtUtils;
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private BlacklistedTokenRepository blacklistedTokenRepository;
+  @Mock private HttpServletResponse response;
+  @Mock private Cookie cookie;
 
   private RegisterRequest request;
   private AppUser user;
@@ -137,7 +144,8 @@ class AuthenticationServiceTest {
   @Test
   public void givenExistingEmailWhenSaveAppUserThenThrowsException() {
     // Given
-    given(userService.userExists(request.getEmail().toLowerCase(), request.getPhoneNumber())).willReturn(true);
+    given(userService.userExists(request.getEmail().toLowerCase(), request.getPhoneNumber()))
+        .willReturn(true);
 
     // When
     UserAlreadyExistsException exception =
@@ -153,7 +161,8 @@ class AuthenticationServiceTest {
   @Test
   public void givenExistingPhoneNumberWhenSaveAppUserThenThrowsException() {
     // Given -
-    given(userService.userExists(request.getEmail().toLowerCase(),request.getPhoneNumber())).willReturn(true);
+    given(userService.userExists(request.getEmail().toLowerCase(), request.getPhoneNumber()))
+        .willReturn(true);
 
     // When
     UserAlreadyExistsException exception =
@@ -337,5 +346,52 @@ class AuthenticationServiceTest {
 
     // Then
     assertThat(exception.getMessage()).isEqualTo("User does not exist");
+  }
+
+  @Test
+  @DisplayName("Successful logout")
+  void givenValidTokenWhenLogoutThenInvalidateTokenAndRemoveRefreshTokenAndClearCookie() {
+    // Given
+    String token = "valid_access_token";
+    String refreshToken = "valid_refresh_token";
+    LocalDateTime expiryDate = LocalDateTime.now().plusMinutes(15);
+
+    given(jwtUtils.extractRefreshTokenFromRequest(servletRequest)).willReturn(refreshToken);
+
+    doNothing().when(refreshTokenRepository).deleteByToken(refreshToken);
+
+    // When
+    String result = authenticationService.logout(token, servletRequest, response);
+
+    // Then
+    assertThat(result).isEqualTo("User successfully logged out");
+    verify(refreshTokenRepository, times(1)).deleteByToken(refreshToken);
+
+    // Verify that cookie was cleared
+    ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+    verify(response, times(1)).addCookie(cookieCaptor.capture());
+
+    Cookie clearedCookie = cookieCaptor.getValue();
+    assertThat(clearedCookie.getName()).isEqualTo("refreshToken");
+    assertThat(clearedCookie.getValue()).isNull();
+    assertThat(clearedCookie.getMaxAge()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("Logout should work even when no refresh token is present")
+  void givenNoRefreshToken_whenLogout_thenInvalidateTokenAndClearCookie() {
+    // Given
+    String token = "valid-access-token";
+    LocalDateTime expiryDate = LocalDateTime.now().plusMinutes(15);
+
+    given(jwtUtils.extractRefreshTokenFromRequest(servletRequest)).willReturn(null);
+
+    // When
+    String result = authenticationService.logout(token, servletRequest, response);
+
+    // Then
+    assertThat(result).isEqualTo("User successfully logged out");
+    verify(refreshTokenRepository, never()).deleteByToken(anyString());
+    verify(response, times(1)).addCookie(any(Cookie.class));
   }
 }


### PR DESCRIPTION
## What does this PR do?
* Implements user logout

## Description of tasks to be completed
* Blacklist access token
* Delete refresh token
* Update documentation
* Write unit tests

## How can this be manually tested?
* Clone the repository
* Open a terminal and `cd` to the project directories
* Install dependencies
* Run the project
* Send a `POST` request to `http://localhost:8080/api/v1/auth/login`
* Copy the access token.
* Send a `POST` request to `http://localhost:8080/api/v1/auth/logout` and append the token to the request header
```
curl --location 'http://localhost:8080/api/v1/auth/logout' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer ${token}' \
--data '

'

```

```
// response
{"status":"OK","message":"Logout successful","data":"User successfully logged out"}

```
## What are the relevant Jira board stories?
[HOM 168](https://wasiu-dev.atlassian.net/browse/HOM-168)