### PR TITLE
set active profile in application.yml file

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: dev
+    active: prod
 
 
 springdoc:


### PR DESCRIPTION
Render ignoring active profile set in render.yaml but picking up the one in application.yml file. So now I'm just changing it to prod in application.yml file.

Downside to this is i'll have to manually change back to dev when working locally.