### PR TITLE
refactor authentication methods (HOM-171)

### DIFF
--- a/src/main/java/com/codeplanks/home360/config/SecurityConfiguration.java
+++ b/src/main/java/com/codeplanks/home360/config/SecurityConfiguration.java
@@ -2,6 +2,7 @@
 package com.codeplanks.home360.config;
 
 import com.codeplanks.home360.exception.CustomAccessDeniedHandler;
+import com.codeplanks.home360.filters.JwtAuthenticationFilter;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -40,7 +41,6 @@ public class SecurityConfiguration {
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
-    System.out.println("Allowed Origins: " + allowedOrigins); // Debugging
     httpSecurity
         .addFilterBefore(new TrailingSlashRedirectFilter(), ChannelProcessingFilter.class)
         .addFilterBefore(jwtAuthFilter, BasicAuthenticationFilter.class)

--- a/src/main/java/com/codeplanks/home360/controller/AuthenticationController.java
+++ b/src/main/java/com/codeplanks/home360/controller/AuthenticationController.java
@@ -108,7 +108,7 @@ public class AuthenticationController {
   })
   @PostMapping("/login")
   public ResponseEntity<SuccessDataResponse<AuthenticationResponse>> login(
-      @RequestBody AuthenticationRequest request, HttpServletResponse response) {
+      @Valid @RequestBody AuthenticationRequest request, HttpServletResponse response) {
     SuccessDataResponse<AuthenticationResponse> result = new SuccessDataResponse<>();
     AuthenticationResponse authResponse = authenticationServiceImpl.login(request);
 

--- a/src/main/java/com/codeplanks/home360/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeplanks/home360/filters/JwtAuthenticationFilter.java
@@ -1,6 +1,9 @@
 /* (C)2024-2025 */
-package com.codeplanks.home360.config;
+package com.codeplanks.home360.filters;
 
+import com.codeplanks.home360.config.JwtService;
+import com.codeplanks.home360.exception.UnAuthorizedException;
+import com.codeplanks.home360.repository.BlacklistedTokenRepository;
 import com.codeplanks.home360.utils.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -34,6 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Qualifier("handlerExceptionResolver")
   private final HandlerExceptionResolver resolver;
 
+  private final BlacklistedTokenRepository blacklistedTokenRepository;
   Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
   @Override
@@ -60,6 +64,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     try {
       jwt = authHeader.substring(7);
 
+      if (isTokenBlacklisted(jwt)) {
+        logger.warn(
+            "Blacklisted JWT received for user (attempting to extract): {}",
+            jwtService.extractUsername(jwt));
+
+        resolver.resolveException(
+            request, response, null, new UnAuthorizedException("Invalid token"));
+        return;
+      }
+
       if (jwtUtils.validateToken(jwt)) {
         username = jwtService.extractUsername(jwt);
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
@@ -78,11 +92,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       logger.error("JWT Error: {}", exception.getMessage());
       resolver.resolveException(request, response, null, exception);
       return;
+    } catch (UnAuthorizedException exception) {
+      logger.error("Blacklisted JWT error: {}", exception.getMessage());
+      return;
     } catch (Exception exception) {
       logger.error("Unexpected error: {}", exception.getMessage());
       resolver.resolveException(request, response, null, exception);
       return;
     }
     filterChain.doFilter(request, response);
+  }
+
+  private boolean isTokenBlacklisted(String token) {
+    return blacklistedTokenRepository.findByToken(token).isPresent();
   }
 }

--- a/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
+++ b/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
@@ -1,5 +1,5 @@
-/* (C)2024 */
-package com.codeplanks.home360.config;
+/* (C)2024-2025 */
+package com.codeplanks.home360.filters;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.bucket4j.Bucket;
@@ -60,7 +60,7 @@ public class RateLimitingFilter implements Filter {
           authenticatedBucketCache.computeIfAbsent(
               userId, newBucket -> createNewAuthenticatedBucket());
       if (!authBucket.tryConsume(1)) {
-        logger.debug("rate limiting abuse: " + userId);
+        logger.warn("rate limiting abuse: {}", userId);
         sendErrorResponse(httpResponse, "Rate limit exceeded for authenticated user.");
         return;
       }
@@ -69,7 +69,7 @@ public class RateLimitingFilter implements Filter {
           unAuthenticatedBucketCache.computeIfAbsent(
               clientIpAddress, newBucket -> createNewUnAuthenticatedBucket());
       if (!unAuthBucket.tryConsume(1)) {
-        logger.debug("rate limiting abuse: " + clientIpAddress);
+        logger.warn("rate limiting abuse by unauthenticated user: {}", clientIpAddress);
         sendErrorResponse(httpResponse, "Rate limit exceeded for unauthenticated user.");
         return;
       }
@@ -109,7 +109,7 @@ public class RateLimitingFilter implements Filter {
 
     String jsonResponse = objectMapper.writeValueAsString(errorDetails);
     response.getWriter().write(jsonResponse);
-    logger.debug("Rate limiting Error: " + message);
+    logger.error("Rate limiting Error: {}", message);
   }
 
   private String getCurrentTimestamp() {

--- a/src/main/java/com/codeplanks/home360/filters/RequestLoggingFilterConfig.java
+++ b/src/main/java/com/codeplanks/home360/filters/RequestLoggingFilterConfig.java
@@ -1,4 +1,5 @@
-package com.codeplanks.home360.config;
+/* (C)2025 */
+package com.codeplanks.home360.filters;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/codeplanks/home360/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/BlacklistedTokenRepository.java
@@ -2,10 +2,13 @@
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.auth.BlacklistedToken;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
   boolean existsByToken(String token);
+
+  Optional<BlacklistedToken> findByToken(String token);
 }

--- a/src/main/java/com/codeplanks/home360/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/RefreshTokenRepository.java
@@ -4,6 +4,7 @@ package com.codeplanks.home360.repository;
 import com.codeplanks.home360.domain.refreshToken.RefreshToken;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Wasiu Idowu
@@ -11,5 +12,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
   Optional<RefreshToken> findByToken(String token);
 
+  @Transactional
   void deleteByToken(String token);
 }

--- a/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
@@ -14,6 +14,7 @@ import com.codeplanks.home360.exception.NotFoundException;
 import com.codeplanks.home360.exception.UserAlreadyExistsException;
 import com.codeplanks.home360.repository.RefreshTokenRepository;
 import com.codeplanks.home360.repository.UserRepository;
+import com.codeplanks.home360.utils.GeneralUtils;
 import com.codeplanks.home360.utils.JwtUtils;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.Cookie;
@@ -26,13 +27,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataAccessException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
  * @author Wasiu Idowu
@@ -52,6 +56,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
   private final ApplicationEventPublisher publisher;
   private final VerificationTokenServiceImpl verificationTokenService;
   private final JwtUtils jwtUtils;
+  private final RefreshTokenRepository refreshTokenRepository;
   Logger logger = LoggerFactory.getLogger(AuthenticationServiceImpl.class);
 
   @Value("${application.frontend.reset-password.url}")
@@ -60,11 +65,10 @@ public class AuthenticationServiceImpl implements AuthenticationService {
   @Value("${application.frontend.verify-email.url}")
   private String emailVerificationUrl;
 
-  private final RefreshTokenRepository refreshTokenRepository;
-
   @Override
   public AppUser register(RegisterRequest request) throws UserAlreadyExistsException {
-    if (userService.userExists(request.getEmail().toLowerCase(), request.getPhoneNumber())) {
+    String email = GeneralUtils.toLowerCase(request.getEmail());
+    if (userService.userExists(email, request.getPhoneNumber())) {
       throw new UserAlreadyExistsException("User with email or phone number already exists");
     }
 
@@ -72,34 +76,27 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         AppUser.builder()
             .firstName(request.getFirstName())
             .lastName(request.getLastName())
-            .email(request.getEmail().toLowerCase())
+            .email(email)
             .address(request.getAddress())
             .phoneNumber(request.getPhoneNumber())
             .password(passwordEncoder.encode(request.getPassword()))
             .role(Role.USER)
             .build();
     userRepository.save(user);
-    publisher.publishEvent(new RegistrationCompleteEvent(user, applicationUrl(servletRequest)));
+    publisher.publishEvent(
+        new RegistrationCompleteEvent(user, buildApplicationUrl(servletRequest)));
     return user;
   }
 
   @Override
   public AuthenticationResponse login(AuthenticationRequest request)
       throws BadCredentialsException {
-    boolean userExist = userService.emailExists(request.getEmail().toLowerCase());
-
-    if (!userExist) {
-      logger.error("User does not exist: " + request.getEmail());
-      throw new BadCredentialsException("Incorrect email/password");
-    }
+    String email = GeneralUtils.toLowerCase(request.getEmail());
     try {
       Authentication authentication =
           authenticationManager.authenticate(
-              new UsernamePasswordAuthenticationToken(
-                  request.getEmail().toLowerCase(), request.getPassword()));
-      if (!authentication.isAuthenticated()) {
-        throw new NotFoundException("Incorrect email/password");
-      }
+              new UsernamePasswordAuthenticationToken(email, request.getPassword()));
+
       AppUser user = userService.getUser(request.getEmail().toLowerCase());
       RefreshToken refreshToken = refreshTokenServiceImpl.generateRefreshToken(user);
       TokenResponse tokenResponse =
@@ -115,6 +112,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
           .build();
 
     } catch (BadCredentialsException exception) {
+      logger.error("Authentication failed for user: {}", request.getEmail());
       throw new BadCredentialsException("Incorrect username/password");
     }
   }
@@ -166,18 +164,37 @@ public class AuthenticationServiceImpl implements AuthenticationService {
   @Transactional
   @Override
   public String logout(String token, HttpServletRequest request, HttpServletResponse response) {
-    jwtUtils.invalidateToken(token);
-
     String refreshToken = jwtUtils.extractRefreshTokenFromRequest(request);
-    if (refreshToken != null) {
-      refreshTokenRepository.deleteByToken(refreshToken);
+
+    String userEmail = jwtUtils.extractSubject(token);
+
+    try {
+      jwtUtils.invalidateToken(token);
+      if (userEmail != null) {
+        logger.info("Access token blacklisted for user: {}", userEmail);
+      }
+    } catch (DataAccessException exception) {
+      logger.warn(
+          "Error blacklisting access token for user {}: {}", userEmail, exception.getMessage());
     }
+
+    if (refreshToken != null) {
+
+      try {
+        refreshTokenRepository.deleteByToken(refreshToken);
+        logger.info("Refresh token deleted: {}", refreshToken);
+
+      } catch (DataAccessException exception) {
+        logger.warn("Error deleting refresh token {}: {}", refreshToken, exception.getMessage());
+      }
+    }
+
     Cookie cookie = new Cookie("refreshToken", null);
     cookie.setPath("/");
     cookie.setHttpOnly(true);
     cookie.setMaxAge(0);
     response.addCookie(cookie);
-
+    SecurityContextHolder.clearContext();
     return "User successfully logged out";
   }
 
@@ -191,12 +208,11 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     eventListener.sendPasswordResetEmail(url);
   }
 
-  private String applicationUrl(HttpServletRequest request) {
-    return "http://"
-        + request.getServerName()
-        + ":"
-        + request.getServerPort()
-        + "/api/v1/auth"
-        + request.getContextPath();
+  private String buildApplicationUrl(HttpServletRequest request) {
+    return ServletUriComponentsBuilder.fromRequestUri(request)
+        .replacePath("/api/v1/auth" + request.getContextPath())
+        .replaceQuery(null)
+        .build()
+        .toUriString();
   }
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -107,7 +107,7 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     return listingEnquiry;
   }
 
-  @Caching(evict = {@CacheEvict(value = "listingEnquiry", key = "#enquiryMessageId")})
+  //  @Caching(evict = {@CacheEvict(value = "listingEnquiry", key = "#enquiryMessageId")})
   @Override
   public Boolean markMessageAsRead(String enquiryMessageId) {
     Query query = createQuery(enquiryMessageId);

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -107,7 +107,6 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     return listingEnquiry;
   }
 
-  //  @Caching(evict = {@CacheEvict(value = "listingEnquiry", key = "#enquiryMessageId")})
   @Override
   public Boolean markMessageAsRead(String enquiryMessageId) {
     Query query = createQuery(enquiryMessageId);

--- a/src/main/java/com/codeplanks/home360/utils/GeneralUtils.java
+++ b/src/main/java/com/codeplanks/home360/utils/GeneralUtils.java
@@ -1,0 +1,8 @@
+/* (C)2025 */
+package com.codeplanks.home360.utils;
+
+public class GeneralUtils {
+  public static String toLowerCase(String stringVal) {
+    return stringVal != null ? stringVal.toLowerCase() : null;
+  }
+}

--- a/src/main/java/com/codeplanks/home360/utils/JwtUtils.java
+++ b/src/main/java/com/codeplanks/home360/utils/JwtUtils.java
@@ -80,4 +80,9 @@ public class JwtUtils {
     }
     return null;
   }
+
+  public String extractSubject(String token) {
+    Claims claims = extractAllClaims(token);
+    return claims.getSubject();
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: prod
+    active: dev
 
 
 springdoc:

--- a/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
@@ -180,10 +180,10 @@ class AuthenticationServiceTest {
     // Given
     AuthenticationRequest authRequest =
         new AuthenticationRequest("elaeis@example.com", userPassword);
-    given(userService.emailExists(authRequest.getEmail())).willReturn(true);
+//    given(userService.emailExists(authRequest.getEmail())).willReturn(true);
     given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
         .willReturn(authentication);
-    given(authentication.isAuthenticated()).willReturn(true);
+//    given(authentication.isAuthenticated()).willReturn(true);
     given(userService.getUser(authRequest.getEmail().toLowerCase())).willReturn(user);
     given(jwtService.generateToken(user)).willReturn(token);
     given(refreshTokenService.generateRefreshToken(user)).willReturn(refreshToken);
@@ -210,14 +210,17 @@ class AuthenticationServiceTest {
     // Given
     AuthenticationRequest authRequest =
         new AuthenticationRequest("nonexistent@example.com", "password123");
-    given(userService.emailExists(authRequest.getEmail())).willReturn(false);
+//    given(userService.emailExists(authRequest.getEmail())).willReturn(false);
 
+    given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).willThrow(new BadCredentialsException("Incorrect username/password"));
     // When
     assertThrows(BadCredentialsException.class, () -> authenticationService.login(authRequest));
 
     // Then
-    verify(authenticationManager, never())
-        .authenticate(any(UsernamePasswordAuthenticationToken.class));
+
+    verify(authenticationManager, times(1))
+            .authenticate(any(UsernamePasswordAuthenticationToken.class));
+    verify(userService, never()).getUser(any());
   }
 
   @DisplayName("incorrect password")
@@ -227,7 +230,6 @@ class AuthenticationServiceTest {
         new AuthenticationRequest("elaeis@example.com", "password123");
 
     // Given
-    given(userService.emailExists(authenticationRequest.getEmail())).willReturn(true);
     given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
         .willThrow(new BadCredentialsException("Incorrect username/password"));
 
@@ -238,7 +240,7 @@ class AuthenticationServiceTest {
     // Then
     verify(authenticationManager, times(1))
         .authenticate(any(UsernamePasswordAuthenticationToken.class));
-    verify(userService, times(1)).emailExists(authenticationRequest.getEmail());
+    verify(userService, never()).getUser(any());
   }
 
   @DisplayName("verify user successfully")


### PR DESCRIPTION
## What does this  PR do?
- Refactor authentication for enhanced clarity, robustness, and maintainability

## Description of tasks to be completed
 - [x] Add logging to rate limiting filter
 - [x] Add `@Valid` annotation to login controller request body
 - [x] Make delete by token method in the refresh token  repository layer a transaction
 - [x] Unnecessary check to see if Authentication manager authenicated returns true was removed.
 - [x] Logout method in the service layer was refactored to invalidate all refresh tokens associated with a user upon logout
 - [x] The method to build application url was refactored and renamed to buildApplicatinUrl.
 - [x] All filters were relocated from config package to filter package
 - [x] JwtAuthentication filter was refactored to handle blacklisted token and return UnAuthorizedException

## What are the relevant Jira board stories?
[HOM-171](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-171)

[HOM-171]: https://wasiu-dev.atlassian.net/browse/HOM-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ