### PR TITLE
refactor: extract enquiry messages into separate collection (HOM-177)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.passay</groupId>
             <artifactId>passay</artifactId>
             <version>1.6.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.37.0</version>
+                <version>2.46.1</version>
                 <configuration>
                     <!-- optional: limit format enforcement to just the files changed by this feature branch -->
                     <ratchetFrom>origin/develop</ratchetFrom>

--- a/src/main/java/com/codeplanks/home360/config/MongoConfig.java
+++ b/src/main/java/com/codeplanks/home360/config/MongoConfig.java
@@ -14,7 +14,9 @@ public class MongoConfig {
     return new MongoCustomConversions(
         List.of(
             new ArrayListToStringConverter(),
-            new StringToListingEnquiryMessageReplyArrayListConverter()
+            new StringToListingEnquiryMessageReplyArrayListConverter(),
+            new ZonedDateTimeToDateConverter(),
+            new DateToZonedDateTimeConverter()
             ));
   }
 }

--- a/src/main/java/com/codeplanks/home360/config/MongoConfig.java
+++ b/src/main/java/com/codeplanks/home360/config/MongoConfig.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.config;
 
 import com.codeplanks.home360.converter.*;
@@ -16,7 +16,6 @@ public class MongoConfig {
             new ArrayListToStringConverter(),
             new StringToListingEnquiryMessageReplyArrayListConverter(),
             new ZonedDateTimeToDateConverter(),
-            new DateToZonedDateTimeConverter()
-            ));
+            new DateToZonedDateTimeConverter()));
   }
 }

--- a/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
@@ -115,12 +115,13 @@ public class ListingEnquiryController {
   public ResponseEntity<SuccessDataResponse<PaginatedListingEnquiriesResponse>> getListingEnquiries(
       @RequestParam(value = "page", defaultValue = "1") int page,
       @RequestParam(value = "size", defaultValue = "25") int size,
-      @RequestParam(required = false) Integer senderId) {
+      @RequestParam(required = false) Integer senderId,
+      @RequestParam(required = false) EnquiryStatus status) {
     Integer agentId = userService.extractUserId();
     SuccessDataResponse<PaginatedListingEnquiriesResponse> listingEnquiries =
         new SuccessDataResponse<>();
     listingEnquiries.setData(
-        listingEnquiryService.getListingEnquiries(page - 1, size, senderId, agentId));
+        listingEnquiryService.getListingEnquiries(page - 1, size, senderId, agentId, status));
     listingEnquiries.setMessage("Listing enquiries retrieved successfully");
     listingEnquiries.setStatus(HttpStatus.OK);
     return new ResponseEntity<>(listingEnquiries, HttpStatus.OK);
@@ -310,12 +311,31 @@ public class ListingEnquiryController {
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
+  @Operation(
+      summary = "Get total unread message count",
+      description = "Returns the sum of all unread messages for the current user",
+      tags = {"GET"})
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
+  })
+  @GetMapping("/unread-count")
+  public ResponseEntity<SuccessDataResponse<Integer>> getTotalUnreadCount() {
+    SuccessDataResponse<Integer> response = new SuccessDataResponse<>();
+    response.setData(listingEnquiryService.getTotalUnreadCount());
+    response.setMessage("Total unread count retrieved successfully");
+    response.setStatus(HttpStatus.OK);
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
   @MessageExceptionHandler
   @SendToUser("/queue/errors")
   public ApiError handleException(Throwable exception) {
-    logger.error("WebSocket Error: {}", exception.getMessage());
+    logger.error("WebSocket Error: {}", exception.getMessage(), exception);
     return new ApiError(
-        ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        ZonedDateTime.now(ZoneOffset.UTC),
+        HttpStatus.BAD_REQUEST,
+        "An unexpected error occurred. Please try again later.");
   }
 
   @Operation(

--- a/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
@@ -5,8 +5,9 @@ import com.codeplanks.home360.domain.listingEnquiries.*;
 import com.codeplanks.home360.domain.user.AppUser;
 import com.codeplanks.home360.event.ListingEnquiryEvent;
 import com.codeplanks.home360.exception.ApiError;
-import com.codeplanks.home360.service.ListingEnquiryServiceImpl;
-import com.codeplanks.home360.service.UserServiceImpl;
+import com.codeplanks.home360.service.EnquiryMessageService;
+import com.codeplanks.home360.service.ListingEnquiryService;
+import com.codeplanks.home360.service.UserService;
 import com.codeplanks.home360.utils.SuccessDataResponse;
 import com.codeplanks.home360.validation.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,9 +17,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -35,9 +41,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/listing-enquiries")
 @Tag(name = "Listing Enquiries", description = "Listing enquiries management APIs")
 public class ListingEnquiryController {
-  private final ListingEnquiryServiceImpl listingEnquiryService;
+  private final ListingEnquiryService listingEnquiryService;
+  private final EnquiryMessageService enquiryMessageService;
   private final ApplicationEventPublisher eventPublisher;
-  private final UserServiceImpl userService;
+  private final UserService userService;
+
+  private static  final Logger logger = LoggerFactory.getLogger(ListingEnquiryController.class);
 
   @Operation(
       summary = "Create a listing enquiry",
@@ -244,7 +253,7 @@ public class ListingEnquiryController {
         description = "Created successfully",
         content = {
           @Content(
-              schema = @Schema(implementation = ListingEnquiryMessageReply.class),
+              schema = @Schema(implementation = EnquiryMessage.class),
               mediaType = "application/json")
         }),
     @ApiResponse(
@@ -274,17 +283,41 @@ public class ListingEnquiryController {
   })
   @MessageMapping("/chat/{enquiryId}/sendMessage")
   @SendTo("/topic/public.{enquiryId}")
-  public ListingEnquiryMessageReply sendEnquiryReply(
+  public EnquiryMessage sendEnquiryReply(
       @DestinationVariable String enquiryId,
       @Payload ListingEnquiryMessageReplyDTO replyMessage,
       @CurrentUser AppUser currentUser) {
-    return listingEnquiryService.addReplyMessage(enquiryId, replyMessage, currentUser.getId());
+    logger.info("Reply message: {}", replyMessage);
+    return enquiryMessageService.addReplyMessage(enquiryId, replyMessage, currentUser.getId());
+  }
+
+  @Operation(
+      summary = "Get enquiry message history",
+      description = "Returns paginated history of messages for a given enquiry",
+      tags = {"GET"})
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+    @ApiResponse(responseCode = "401", description = "Unauthorized"),
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+  })
+  @GetMapping("/{enquiryId}/messages")
+  public ResponseEntity<SuccessDataResponse<PaginatedListingEnquiriesChat>> getEnquiryHistory(
+      @PathVariable String enquiryId,
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    SuccessDataResponse<PaginatedListingEnquiriesChat> response = new SuccessDataResponse<>();
+    response.setData(enquiryMessageService.getEnquiryMessages(enquiryId, page - 1, size));
+    response.setMessage("Messages retrieved successfully");
+    response.setStatus(HttpStatus.OK);
+    return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   @MessageExceptionHandler
   @SendToUser("/queue/errors")
-  public String handleException(Throwable exception) {
-    return "An error occurred: " + exception.getMessage();
+  public ApiError handleException(Throwable exception) {
+    logger.error("WebSocket Error: {}", exception.getMessage(), exception);
+    return new ApiError(
+        ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
   }
 
   @Operation(

--- a/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
@@ -24,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -230,7 +229,7 @@ public class ListingEnquiryController {
   public ResponseEntity<SuccessDataResponse<Boolean>> markMessageAsRead(
       @PathVariable String listingEnquiryId) {
     SuccessDataResponse<Boolean> response = new SuccessDataResponse<>();
-    response.setData(listingEnquiryService.markMessageAsRead(listingEnquiryId));
+    response.setData(listingEnquiryService.markEnquiryAsRead(listingEnquiryId));
     if (!response.getData()) {
       response.setMessage("Listing enquiry message already  read");
       response.setStatus(HttpStatus.NOT_MODIFIED);
@@ -287,7 +286,6 @@ public class ListingEnquiryController {
       @DestinationVariable String enquiryId,
       @Payload ListingEnquiryMessageReplyDTO replyMessage,
       @CurrentUser AppUser currentUser) {
-    logger.info("Reply message: {}", replyMessage);
     return enquiryMessageService.addReplyMessage(enquiryId, replyMessage, currentUser.getId());
   }
 
@@ -315,7 +313,7 @@ public class ListingEnquiryController {
   @MessageExceptionHandler
   @SendToUser("/queue/errors")
   public ApiError handleException(Throwable exception) {
-    logger.error("WebSocket Error: {}", exception.getMessage(), exception);
+    logger.error("WebSocket Error: {}", exception.getMessage());
     return new ApiError(
         ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
   }

--- a/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
+++ b/src/main/java/com/codeplanks/home360/controller/ListingEnquiryController.java
@@ -1,4 +1,4 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.controller;
 
 import com.codeplanks.home360.domain.listingEnquiries.*;
@@ -27,8 +27,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.annotation.SendToUser;
@@ -45,7 +45,7 @@ public class ListingEnquiryController {
   private final ApplicationEventPublisher eventPublisher;
   private final UserService userService;
 
-  private static  final Logger logger = LoggerFactory.getLogger(ListingEnquiryController.class);
+  private static final Logger logger = LoggerFactory.getLogger(ListingEnquiryController.class);
 
   @Operation(
       summary = "Create a listing enquiry",

--- a/src/main/java/com/codeplanks/home360/converter/DateToZonedDateTimeConverter.java
+++ b/src/main/java/com/codeplanks/home360/converter/DateToZonedDateTimeConverter.java
@@ -1,0 +1,18 @@
+/* (C)2025 */
+package com.codeplanks.home360.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.lang.NonNull;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@ReadingConverter
+public class DateToZonedDateTimeConverter implements Converter<Date, ZonedDateTime> {
+  @Override
+  public ZonedDateTime convert(@NonNull Date source) {
+    return source.toInstant().atZone(ZoneOffset.UTC);
+  }
+}

--- a/src/main/java/com/codeplanks/home360/converter/DateToZonedDateTimeConverter.java
+++ b/src/main/java/com/codeplanks/home360/converter/DateToZonedDateTimeConverter.java
@@ -1,13 +1,12 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.converter;
-
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.convert.ReadingConverter;
-import org.springframework.lang.NonNull;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.lang.NonNull;
 
 @ReadingConverter
 public class DateToZonedDateTimeConverter implements Converter<Date, ZonedDateTime> {

--- a/src/main/java/com/codeplanks/home360/converter/ZonedDateTimeToDateConverter.java
+++ b/src/main/java/com/codeplanks/home360/converter/ZonedDateTimeToDateConverter.java
@@ -1,12 +1,11 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.converter;
-
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.convert.WritingConverter;
-import org.springframework.lang.NonNull;
 
 import java.time.ZonedDateTime;
 import java.util.Date;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.lang.NonNull;
 
 @WritingConverter
 public class ZonedDateTimeToDateConverter implements Converter<ZonedDateTime, Date> {

--- a/src/main/java/com/codeplanks/home360/converter/ZonedDateTimeToDateConverter.java
+++ b/src/main/java/com/codeplanks/home360/converter/ZonedDateTimeToDateConverter.java
@@ -1,0 +1,17 @@
+/* (C)2025 */
+package com.codeplanks.home360.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.lang.NonNull;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@WritingConverter
+public class ZonedDateTimeToDateConverter implements Converter<ZonedDateTime, Date> {
+  @Override
+  public Date convert(@NonNull ZonedDateTime source) {
+    return Date.from(source.toInstant());
+  }
+}

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryMessage.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryMessage.java
@@ -1,0 +1,39 @@
+/* (C)2025 */
+package com.codeplanks.home360.domain.listingEnquiries;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "enquiryMessages")
+public class EnquiryMessage {
+  @Id private String id;
+
+  @Indexed
+  @Field(name = "enquiryId", targetType = FieldType.STRING)
+  private String enquiryId;
+
+  @Field(name = "senderId", targetType = FieldType.INT32)
+  private Integer senderId;
+
+  @Field(name = "receiverId", targetType = FieldType.INT32)
+  private Integer receiverId;
+
+  @Field(name = "content", targetType = FieldType.STRING)
+  private String content;
+
+  @Field(name = "created_at", targetType = FieldType.DATE_TIME)
+  private ZonedDateTime createdAt;
+}

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryMessage.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryMessage.java
@@ -1,6 +1,7 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.domain.listingEnquiries;
 
+import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,8 +11,6 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldType;
-
-import java.time.ZonedDateTime;
 
 @Data
 @Builder

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryStatus.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryStatus.java
@@ -2,8 +2,8 @@
 package com.codeplanks.home360.domain.listingEnquiries;
 
 public enum EnquiryStatus {
-  PENDING,    // New Lead, not yet acknowledged
-  ACTIVE,     // Ongoing conversation
-  ARCHIVED,   // Agent has finished/closed the lead
-  COMPLETED   // Lead resulted in a successful rental/sale
+  PENDING, // New Lead, not yet acknowledged
+  ACTIVE, // Ongoing conversation
+  ARCHIVED, // Agent has finished/closed the lead
+  COMPLETED // Lead resulted in a successful rental/sale
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryStatus.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/EnquiryStatus.java
@@ -1,0 +1,9 @@
+/* (C)2025-2026 */
+package com.codeplanks.home360.domain.listingEnquiries;
+
+public enum EnquiryStatus {
+  PENDING,    // New Lead, not yet acknowledged
+  ACTIVE,     // Ongoing conversation
+  ARCHIVED,   // Agent has finished/closed the lead
+  COMPLETED   // Lead resulted in a successful rental/sale
+}

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
@@ -68,7 +68,15 @@ public class ListingEnquiry {
   @Field(name = "last_message_at", targetType = FieldType.DATE_TIME)
   private ZonedDateTime lastMessageAt;
 
-  @Field(name = "read", targetType = FieldType.BOOLEAN)
+  @Field(name = "unreadCountByAgent", targetType = FieldType.INT32)
   @Builder.Default
-  private boolean read = false;
+  private int unreadCountByAgent = 0;
+
+  @Field(name = "unreadCountByInquirer", targetType = FieldType.INT32)
+  @Builder.Default
+  private int unreadCountByInquirer = 0;
+
+  @Field(name = "status")
+  @Builder.Default
+  private EnquiryStatus status = EnquiryStatus.PENDING;
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
@@ -1,12 +1,10 @@
-/* (C)2024 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.domain.listingEnquiries;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiry.java
@@ -4,7 +4,7 @@ package com.codeplanks.home360.domain.listingEnquiries;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -65,13 +65,12 @@ public class ListingEnquiry {
   private Integer agentId;
 
   @Field(name = "created_at", targetType = FieldType.DATE_TIME)
-  private LocalDateTime createdAt;
+  private ZonedDateTime createdAt;
+
+  @Field(name = "last_message_at", targetType = FieldType.DATE_TIME)
+  private ZonedDateTime lastMessageAt;
 
   @Field(name = "read", targetType = FieldType.BOOLEAN)
   @Builder.Default
   private boolean read = false;
-
-  @Builder.Default
-  @Field(name = "replies")
-  private List<ListingEnquiryMessageReply> replies = new ArrayList<>();
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryDTO.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.domain.listingEnquiries;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryDTO.java
@@ -4,7 +4,7 @@ package com.codeplanks.home360.domain.listingEnquiries;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -65,5 +65,5 @@ public class ListingEnquiryDTO {
 
   private Integer userId;
 
-  private LocalDateTime createdAt;
+  private ZonedDateTime createdAt;
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
@@ -5,15 +5,17 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class ListingEnquiryMessageReplyDTO {
   @NotNull(message = "Agent ID is required")
-  private int agentId;
+  private Integer agentId;
 
   @NotNull(message = "Enquirer ID is required")
-  private int enquirerId;
+  private Integer enquirerId;
 
   @NotNull(message = "message content is required")
   @Size(min = 2, message = "message should be at least 2 characters")

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
@@ -24,5 +24,5 @@ public class ListingEnquiryMessageReplyDTO {
   @NotNull(message = "Enquiry ID is required")
   private String enquiryId;
 
-  private int senderId;
+  private Integer senderId;
 }

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/ListingEnquiryMessageReplyDTO.java
@@ -1,4 +1,4 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.domain.listingEnquiries;
 
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/PaginatedListingEnquiriesChat.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/PaginatedListingEnquiriesChat.java
@@ -1,0 +1,20 @@
+package com.codeplanks.home360.domain.listingEnquiries;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaginatedListingEnquiriesChat {
+  private int currentPage;
+  private long totalItems;
+  private int totalPages;
+  private boolean hasNext;
+  private List<EnquiryMessage> items;
+}

--- a/src/main/java/com/codeplanks/home360/domain/listingEnquiries/PaginatedListingEnquiriesChat.java
+++ b/src/main/java/com/codeplanks/home360/domain/listingEnquiries/PaginatedListingEnquiriesChat.java
@@ -1,11 +1,11 @@
+/* (C)2026 */
 package com.codeplanks.home360.domain.listingEnquiries;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Data
 @Builder

--- a/src/main/java/com/codeplanks/home360/domain/user/AppUser.java
+++ b/src/main/java/com/codeplanks/home360/domain/user/AppUser.java
@@ -2,7 +2,7 @@
 package com.codeplanks.home360.domain.user;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import lombok.*;
@@ -62,11 +62,11 @@ public class AppUser implements UserDetails {
       nullable = false,
       columnDefinition = "TIMESTAMP WITH TIME ZONE DEFAULT NOW()")
   @CreationTimestamp
-  private LocalDateTime createdAt;
+  private ZonedDateTime createdAt;
 
   @Column(name = "updatedAt", nullable = false)
   @UpdateTimestamp
-  private LocalDateTime updatedAt;
+  private ZonedDateTime updatedAt;
 
   @Column(name = "role", length = 50, nullable = false)
   @Enumerated(EnumType.STRING)
@@ -83,8 +83,8 @@ public class AppUser implements UserDetails {
       String password,
       String address,
       String phoneNumber,
-      LocalDateTime createdAt,
-      LocalDateTime updatedAt,
+      ZonedDateTime createdAt,
+      ZonedDateTime updatedAt,
       Role role) {
     this.firstName = firstName;
     this.lastName = lastName;

--- a/src/main/java/com/codeplanks/home360/domain/user/AppUserDTO.java
+++ b/src/main/java/com/codeplanks/home360/domain/user/AppUserDTO.java
@@ -2,7 +2,8 @@
 package com.codeplanks.home360.domain.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,8 +21,8 @@ public class AppUserDTO {
   private String email;
   private String address;
   private String phoneNumber;
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
+  private ZonedDateTime createdAt;
+  private ZonedDateTime updatedAt;
   private Role role;
   @Builder.Default private boolean isEnabled = false;
 }

--- a/src/main/java/com/codeplanks/home360/exception/ApiError.java
+++ b/src/main/java/com/codeplanks/home360/exception/ApiError.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 
@@ -16,19 +16,19 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiError {
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
-  private LocalDateTime timestamp;
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
+  private ZonedDateTime timestamp;
   private HttpStatus status;
   private String message;
   private  List<String> errors;
 
-  public ApiError(LocalDateTime timestamp, HttpStatus status, String message) {
+  public ApiError(ZonedDateTime timestamp, HttpStatus status, String message) {
     this.timestamp = timestamp;
     this.status = status;
     this.message = message;
   }
 
-  public ApiError(LocalDateTime timestamp, HttpStatus status, List<String> errors) {
+  public ApiError(ZonedDateTime timestamp, HttpStatus status, List<String> errors) {
     this.timestamp = timestamp;
     this.status = status;
     this.errors = errors;

--- a/src/main/java/com/codeplanks/home360/exception/ApiError.java
+++ b/src/main/java/com/codeplanks/home360/exception/ApiError.java
@@ -1,13 +1,12 @@
+/* (C)2026 */
 package com.codeplanks.home360.exception;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.*;
-import org.springframework.http.HttpStatus;
-
 import java.time.ZonedDateTime;
 import java.util.List;
-
+import lombok.*;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Setter
@@ -18,9 +17,10 @@ public class ApiError {
 
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private ZonedDateTime timestamp;
+
   private HttpStatus status;
   private String message;
-  private  List<String> errors;
+  private List<String> errors;
 
   public ApiError(ZonedDateTime timestamp, HttpStatus status, String message) {
     this.timestamp = timestamp;

--- a/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
@@ -9,7 +9,8 @@ import jakarta.mail.AuthenticationFailedException;
 import jakarta.validation.ConstraintViolationException;
 import java.io.NotSerializableException;
 import java.net.ConnectException;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -46,7 +47,7 @@ public class GlobalExceptionHandler {
             .map(DefaultMessageSourceResolvable::getDefaultMessage)
             .toList();
 
-    ApiError apiError = new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, errors);
+    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, errors);
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -54,7 +55,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(UnAuthorizedException.class)
   public ResponseEntity<ApiError> handleUnAuthorizedException(UnAuthorizedException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.UNAUTHORIZED, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.UNAUTHORIZED, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.UNAUTHORIZED);
   }
@@ -63,7 +64,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleIllegalArgumentException(
       IllegalArgumentException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -73,7 +74,7 @@ public class GlobalExceptionHandler {
     ApiError apiError = new ApiError();
     apiError.setStatus(HttpStatus.BAD_REQUEST);
     apiError.setMessage("Item does not exist: " + exception.getMessage());
-    apiError.setTimestamp(LocalDateTime.now());
+    apiError.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -83,7 +84,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleMethodNotAllowedException(
       HttpRequestMethodNotSupportedException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.METHOD_NOT_ALLOWED, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.METHOD_NOT_ALLOWED, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.METHOD_NOT_ALLOWED);
   }
@@ -93,7 +94,7 @@ public class GlobalExceptionHandler {
     ApiError apiError = new ApiError();
     apiError.setStatus(HttpStatus.BAD_REQUEST);
     apiError.setMessage("User is currently disabled: " + exception.getMessage());
-    apiError.setTimestamp(LocalDateTime.now());
+    apiError.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -104,7 +105,7 @@ public class GlobalExceptionHandler {
     ApiError apiError = new ApiError();
     apiError.setStatus(HttpStatus.BAD_REQUEST);
     apiError.setMessage(exception.getMessage());
-    apiError.setTimestamp(LocalDateTime.now());
+    apiError.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -114,7 +115,7 @@ public class GlobalExceptionHandler {
     ApiError apiError = new ApiError();
     apiError.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
     apiError.setMessage(exception.getMessage());
-    apiError.setTimestamp(LocalDateTime.now());
+    apiError.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -127,7 +128,7 @@ public class GlobalExceptionHandler {
     ApiError apiError = new ApiError();
     apiError.setStatus(HttpStatus.BAD_REQUEST);
     apiError.setMessage(exception.getMessage());
-    apiError.setTimestamp(LocalDateTime.now());
+    apiError.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
 
@@ -137,7 +138,7 @@ public class GlobalExceptionHandler {
     ApiError apiError = new ApiError();
     apiError.setStatus(HttpStatus.BAD_REQUEST);
     apiError.setMessage(exception.getMessage());
-    apiError.setTimestamp(LocalDateTime.now());
+    apiError.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
 
@@ -146,14 +147,14 @@ public class GlobalExceptionHandler {
     ApiError apiError = new ApiError();
     apiError.setStatus(HttpStatus.BAD_REQUEST);
     apiError.setMessage(exception.getMessage());
-    apiError.setTimestamp(LocalDateTime.now());
+    apiError.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(AccessDeniedException.class)
   public ResponseEntity<ApiError> handleForbiddenException(AccessDeniedException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.FORBIDDEN, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.FORBIDDEN, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.FORBIDDEN);
   }
@@ -161,7 +162,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MappingException.class)
   public ResponseEntity<ApiError> handleMappingException(MappingException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -170,7 +171,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleConversionFailedException(
       ConversionFailedException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -178,7 +179,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(DateTimeParseException.class)
   public ResponseEntity<ApiError> handleDateTimeParseException(DateTimeParseException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -187,7 +188,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleDataAccessResourceFailureException(
       DataAccessResourceFailureException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -196,7 +197,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleMongoSocketOpenException(
       MongoSocketOpenException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -204,7 +205,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(ConnectException.class)
   public ResponseEntity<ApiError> handleConnectException(ConnectException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -213,7 +214,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleHttpMessageNotReadableException(
       HttpMessageNotReadableException exception) {
     String readableMessage = extractEnumErrorMessage(exception.getMessage());
-    ApiError apiError = new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, readableMessage);
+    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, readableMessage);
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -222,7 +223,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleServiceException(ServiceException exception) {
 
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -230,7 +231,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleSerializationException(SerializationException exception) {
 
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -239,7 +240,7 @@ public class GlobalExceptionHandler {
       InvalidDefinitionException exception) {
 
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -248,7 +249,7 @@ public class GlobalExceptionHandler {
       NotSerializableException exception) {
 
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -256,7 +257,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleClassCastException(ClassCastException exception) {
 
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -264,7 +265,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleDuplicateSessionException(
       DuplicateSessionException exception) {
     ApiError apiError =
-        new ApiError(LocalDateTime.now(), HttpStatus.CONFLICT, exception.getMessage());
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.CONFLICT, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.CONFLICT);
   }

--- a/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeplanks/home360/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.exception;
 
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
@@ -14,7 +14,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.NoSuchElementException;
-
 import org.eclipse.angus.mail.util.MailConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +46,8 @@ public class GlobalExceptionHandler {
             .map(DefaultMessageSourceResolvable::getDefaultMessage)
             .toList();
 
-    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, errors);
+    ApiError apiError =
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, errors);
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -55,7 +55,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(UnAuthorizedException.class)
   public ResponseEntity<ApiError> handleUnAuthorizedException(UnAuthorizedException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.UNAUTHORIZED, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.UNAUTHORIZED, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.UNAUTHORIZED);
   }
@@ -64,7 +65,8 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleIllegalArgumentException(
       IllegalArgumentException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -84,7 +86,10 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleMethodNotAllowedException(
       HttpRequestMethodNotSupportedException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.METHOD_NOT_ALLOWED, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC),
+            HttpStatus.METHOD_NOT_ALLOWED,
+            exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.METHOD_NOT_ALLOWED);
   }
@@ -154,7 +159,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(AccessDeniedException.class)
   public ResponseEntity<ApiError> handleForbiddenException(AccessDeniedException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.FORBIDDEN, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.FORBIDDEN, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.FORBIDDEN);
   }
@@ -162,7 +168,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MappingException.class)
   public ResponseEntity<ApiError> handleMappingException(MappingException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -171,7 +178,8 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleConversionFailedException(
       ConversionFailedException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -179,7 +187,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(DateTimeParseException.class)
   public ResponseEntity<ApiError> handleDateTimeParseException(DateTimeParseException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -188,7 +197,8 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleDataAccessResourceFailureException(
       DataAccessResourceFailureException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -197,7 +207,8 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleMongoSocketOpenException(
       MongoSocketOpenException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -205,7 +216,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(ConnectException.class)
   public ResponseEntity<ApiError> handleConnectException(ConnectException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -214,7 +226,8 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleHttpMessageNotReadableException(
       HttpMessageNotReadableException exception) {
     String readableMessage = extractEnumErrorMessage(exception.getMessage());
-    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, readableMessage);
+    ApiError apiError =
+        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.BAD_REQUEST, readableMessage);
 
     return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
   }
@@ -223,7 +236,10 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleServiceException(ServiceException exception) {
 
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC),
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -231,7 +247,10 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleSerializationException(SerializationException exception) {
 
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC),
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -240,7 +259,10 @@ public class GlobalExceptionHandler {
       InvalidDefinitionException exception) {
 
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC),
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -249,7 +271,10 @@ public class GlobalExceptionHandler {
       NotSerializableException exception) {
 
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC),
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -257,7 +282,10 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleClassCastException(ClassCastException exception) {
 
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC),
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            exception.getMessage());
     return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
@@ -265,7 +293,8 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiError> handleDuplicateSessionException(
       DuplicateSessionException exception) {
     ApiError apiError =
-        new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.CONFLICT, exception.getMessage());
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.CONFLICT, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.CONFLICT);
   }

--- a/src/main/java/com/codeplanks/home360/exception/UserExceptionHandler.java
+++ b/src/main/java/com/codeplanks/home360/exception/UserExceptionHandler.java
@@ -1,6 +1,10 @@
+/* (C)2026 */
 package com.codeplanks.home360.exception;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import java.nio.file.AccessDeniedException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -8,35 +12,39 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import java.nio.file.AccessDeniedException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-
 @ControllerAdvice
 public class UserExceptionHandler {
 
   @ExceptionHandler(value = {UserAlreadyExistsException.class})
   public ResponseEntity<ApiError> handleUserExistsException(UserAlreadyExistsException exception) {
-    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.CONFLICT, exception.getMessage());
+    ApiError apiError =
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.CONFLICT, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(value = {NotFoundException.class})
   public ResponseEntity<ApiError> handleUserNotFoundException(NotFoundException exception) {
-    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC),HttpStatus.NOT_FOUND, exception.getMessage() );
+    ApiError apiError =
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.NOT_FOUND, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
   }
 
-  @ExceptionHandler(value = {BadCredentialsException.class, AccessDeniedException.class,
-          ExpiredJwtException.class, UsernameNotFoundException.class})
+  @ExceptionHandler(
+      value = {
+        BadCredentialsException.class,
+        AccessDeniedException.class,
+        ExpiredJwtException.class,
+        UsernameNotFoundException.class
+      })
   public ResponseEntity<ApiError> handleBadCredentialsException(RuntimeException exception) {
-    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.UNAUTHORIZED, exception.getMessage());
+    ApiError apiError =
+        new ApiError(
+            ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.UNAUTHORIZED, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.UNAUTHORIZED);
   }
-
 }
-
-

--- a/src/main/java/com/codeplanks/home360/exception/UserExceptionHandler.java
+++ b/src/main/java/com/codeplanks/home360/exception/UserExceptionHandler.java
@@ -9,21 +9,22 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import java.nio.file.AccessDeniedException;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @ControllerAdvice
 public class UserExceptionHandler {
 
   @ExceptionHandler(value = {UserAlreadyExistsException.class})
   public ResponseEntity<ApiError> handleUserExistsException(UserAlreadyExistsException exception) {
-    ApiError apiError = new ApiError(LocalDateTime.now(), HttpStatus.CONFLICT, exception.getMessage());
+    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.CONFLICT, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(value = {NotFoundException.class})
   public ResponseEntity<ApiError> handleUserNotFoundException(NotFoundException exception) {
-    ApiError apiError = new ApiError(LocalDateTime.now(),HttpStatus.NOT_FOUND, exception.getMessage() );
+    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC),HttpStatus.NOT_FOUND, exception.getMessage() );
 
     return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
   }
@@ -31,7 +32,7 @@ public class UserExceptionHandler {
   @ExceptionHandler(value = {BadCredentialsException.class, AccessDeniedException.class,
           ExpiredJwtException.class, UsernameNotFoundException.class})
   public ResponseEntity<ApiError> handleBadCredentialsException(RuntimeException exception) {
-    ApiError apiError = new ApiError(LocalDateTime.now(), HttpStatus.UNAUTHORIZED, exception.getMessage());
+    ApiError apiError = new ApiError(ZonedDateTime.now(ZoneOffset.UTC), HttpStatus.UNAUTHORIZED, exception.getMessage());
 
     return new ResponseEntity<>(apiError, HttpStatus.UNAUTHORIZED);
   }

--- a/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
+++ b/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
@@ -3,6 +3,8 @@ package com.codeplanks.home360.filters;
 
 import com.codeplanks.home360.utils.AppConstants;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bucket;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,7 +15,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -23,9 +24,15 @@ import org.springframework.stereotype.Component;
 public class RateLimitingFilter implements Filter {
   private static final Logger logger = LoggerFactory.getLogger(RateLimitingFilter.class);
   private final ObjectMapper objectMapper = new ObjectMapper();
-  private final Map<String, Bucket> authenticatedBucketCache = new ConcurrentHashMap<>();
-  private final Map<String, Bucket> unAuthenticatedBucketCache = new ConcurrentHashMap<>();
-  private final Map<String, Bucket> loginBucketCache = new ConcurrentHashMap<>();
+
+  private final Cache<String, Bucket> authenticatedBucketCache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(10)).maximumSize(10000).build();
+
+  private final Cache<String, Bucket> unAuthenticatedBucketCache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(10)).maximumSize(10000).build();
+
+  private final Cache<String, Bucket> loginBucketCache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(10)).maximumSize(10000).build();
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -38,14 +45,15 @@ public class RateLimitingFilter implements Filter {
 
     String path = httpServletRequest.getRequestURI();
 
-    if (path.startsWith("/swagger") || path.startsWith("/v1/api-docs") || path.startsWith(AppConstants.WS_ENDPOINT)) {
+    if (path.startsWith("/swagger")
+        || path.startsWith("/v1/api-docs")
+        || path.startsWith(AppConstants.WS_ENDPOINT)) {
       chain.doFilter(request, response);
       return;
     }
 
     if (path.equals("/api/v1/auth/login")) {
-      Bucket loginBucket =
-          loginBucketCache.computeIfAbsent(clientIpAddress, bucket -> createLoginBucket());
+      Bucket loginBucket = loginBucketCache.get(clientIpAddress, k -> createLoginBucket());
       logger.debug(
           "Client IP: {}, Bucket Tokens Available: {}",
           clientIpAddress,
@@ -58,8 +66,7 @@ public class RateLimitingFilter implements Filter {
     } else if (isAuthenticated) {
       String userId = httpServletRequest.getUserPrincipal().getName();
       Bucket authBucket =
-          authenticatedBucketCache.computeIfAbsent(
-              userId, newBucket -> createNewAuthenticatedBucket());
+          authenticatedBucketCache.get(userId, k -> createNewAuthenticatedBucket());
       if (!authBucket.tryConsume(1)) {
         logger.warn("rate limiting abuse: {}", userId);
         sendErrorResponse(httpResponse, "Rate limit exceeded for authenticated user.");
@@ -67,8 +74,7 @@ public class RateLimitingFilter implements Filter {
       }
     } else {
       Bucket unAuthBucket =
-          unAuthenticatedBucketCache.computeIfAbsent(
-              clientIpAddress, newBucket -> createNewUnAuthenticatedBucket());
+          unAuthenticatedBucketCache.get(clientIpAddress, k -> createNewUnAuthenticatedBucket());
       if (!unAuthBucket.tryConsume(1)) {
         logger.warn("rate limiting abuse by unauthenticated user: {}", clientIpAddress);
         sendErrorResponse(httpResponse, "Rate limit exceeded for unauthenticated user.");

--- a/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
+++ b/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
@@ -1,4 +1,4 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.filters;
 
 import com.codeplanks.home360.utils.AppConstants;
@@ -65,8 +65,7 @@ public class RateLimitingFilter implements Filter {
       }
     } else if (isAuthenticated) {
       String userId = httpServletRequest.getUserPrincipal().getName();
-      Bucket authBucket =
-          authenticatedBucketCache.get(userId, k -> createNewAuthenticatedBucket());
+      Bucket authBucket = authenticatedBucketCache.get(userId, k -> createNewAuthenticatedBucket());
       if (!authBucket.tryConsume(1)) {
         logger.warn("rate limiting abuse: {}", userId);
         sendErrorResponse(httpResponse, "Rate limit exceeded for authenticated user.");

--- a/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
+++ b/src/main/java/com/codeplanks/home360/filters/RateLimitingFilter.java
@@ -1,6 +1,7 @@
 /* (C)2024-2025 */
 package com.codeplanks.home360.filters;
 
+import com.codeplanks.home360.utils.AppConstants;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.bucket4j.Bucket;
 import jakarta.servlet.*;
@@ -37,7 +38,7 @@ public class RateLimitingFilter implements Filter {
 
     String path = httpServletRequest.getRequestURI();
 
-    if (path.startsWith("/swagger") || path.startsWith("/v1/api-docs")) {
+    if (path.startsWith("/swagger") || path.startsWith("/v1/api-docs") || path.startsWith(AppConstants.WS_ENDPOINT)) {
       chain.doFilter(request, response);
       return;
     }

--- a/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepository.java
@@ -1,10 +1,12 @@
 /* (C)2024 */
 package com.codeplanks.home360.repository;
 
+import com.codeplanks.home360.domain.listingEnquiries.EnquiryStatus;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomListingEnquiryRepository {
-  Page<ListingEnquiry> findListingEnquiries(Integer agentId, Integer senderId, Pageable pageable);
+  Page<ListingEnquiry> findListingEnquiries(
+      Integer agentId, Integer senderId, EnquiryStatus status, Pageable pageable);
 }

--- a/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepository.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.listingEnquiries.EnquiryStatus;

--- a/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepositoryImpl.java
+++ b/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepositoryImpl.java
@@ -1,4 +1,4 @@
-/* (C)2024 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.listingEnquiries.EnquiryStatus;
@@ -23,7 +23,9 @@ public class CustomListingEnquiryRepositoryImpl implements CustomListingEnquiryR
   public Page<ListingEnquiry> findListingEnquiries(
       Integer agentId, Integer senderId, EnquiryStatus status, Pageable pageable) {
     Query query =
-        fetchListingEnquiries(agentId, senderId, status).with(pageable).collation(getEnglishCollation());
+        fetchListingEnquiries(agentId, senderId, status)
+            .with(pageable)
+            .collation(getEnglishCollation());
     List<ListingEnquiry> listingEnquiries =
         mongoTemplate.find(query, ListingEnquiry.class, "listingEnquiries");
     return PageableExecutionUtils.getPage(

--- a/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepositoryImpl.java
+++ b/src/main/java/com/codeplanks/home360/repository/CustomListingEnquiryRepositoryImpl.java
@@ -1,6 +1,7 @@
 /* (C)2024 */
 package com.codeplanks.home360.repository;
 
+import com.codeplanks.home360.domain.listingEnquiries.EnquiryStatus;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,9 +21,9 @@ public class CustomListingEnquiryRepositoryImpl implements CustomListingEnquiryR
 
   @Override
   public Page<ListingEnquiry> findListingEnquiries(
-      Integer agentId, Integer senderId, Pageable pageable) {
+      Integer agentId, Integer senderId, EnquiryStatus status, Pageable pageable) {
     Query query =
-        fetchListingEnquiries(agentId, senderId).with(pageable).collation(getEnglishCollation());
+        fetchListingEnquiries(agentId, senderId, status).with(pageable).collation(getEnglishCollation());
     List<ListingEnquiry> listingEnquiries =
         mongoTemplate.find(query, ListingEnquiry.class, "listingEnquiries");
     return PageableExecutionUtils.getPage(
@@ -31,7 +32,7 @@ public class CustomListingEnquiryRepositoryImpl implements CustomListingEnquiryR
         () -> mongoTemplate.count(query.limit(-1).skip(-1), ListingEnquiry.class));
   }
 
-  private Query fetchListingEnquiries(Integer agentId, Integer senderId) {
+  private Query fetchListingEnquiries(Integer agentId, Integer senderId, EnquiryStatus status) {
     List<Criteria> criteriaList = new ArrayList<>();
     if (agentId != null) {
       criteriaList.add(Criteria.where("agentId").is(agentId));
@@ -44,7 +45,12 @@ public class CustomListingEnquiryRepositoryImpl implements CustomListingEnquiryR
       throw new IllegalArgumentException("At least one of agentId or senderId must be provided");
     }
 
-    return new Query(new Criteria().orOperator(criteriaList.toArray(new Criteria[0])));
+    Criteria rootCriteria = new Criteria().andOperator(criteriaList.toArray(new Criteria[0]));
+    if (status != null) {
+      rootCriteria = rootCriteria.and("status").is(status);
+    }
+
+    return new Query(rootCriteria);
   }
 
   private Collation getEnglishCollation() {

--- a/src/main/java/com/codeplanks/home360/repository/EnquiryMessageRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/EnquiryMessageRepository.java
@@ -1,4 +1,4 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.listingEnquiries.EnquiryMessage;

--- a/src/main/java/com/codeplanks/home360/repository/EnquiryMessageRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/EnquiryMessageRepository.java
@@ -1,0 +1,13 @@
+/* (C)2025 */
+package com.codeplanks.home360.repository;
+
+import com.codeplanks.home360.domain.listingEnquiries.EnquiryMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EnquiryMessageRepository extends MongoRepository<EnquiryMessage, String> {
+  Page<EnquiryMessage> findByEnquiryId(String enquiryId, Pageable pageable);
+}

--- a/src/main/java/com/codeplanks/home360/repository/ListingEnquiryRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/ListingEnquiryRepository.java
@@ -1,14 +1,11 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ListingEnquiryRepository

--- a/src/main/java/com/codeplanks/home360/repository/ListingEnquiryRepository.java
+++ b/src/main/java/com/codeplanks/home360/repository/ListingEnquiryRepository.java
@@ -2,15 +2,23 @@
 package com.codeplanks.home360.repository;
 
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface ListingEnquiryRepository
     extends MongoRepository<ListingEnquiry, String>, CustomListingEnquiryRepository {
-  @Query(
-      value = "{ 'listingId' : ?0 }",
-      fields =
-          "{ 'firstName' : 1, 'lastName' : 1, 'email' : 1, " + "'phoneNumber' : 1, 'listingId': 1}")
+  @Query(value = "{ 'agentId': ?0 }", fields = "{ 'unreadCountByAgent': 1 }")
+  List<ListingEnquiry> findAgentUnreadCounts(int agentId);
+
+  @Query(value = "{ 'userId': ?0 }", fields = "{ 'unreadCountByInquirer': 1 }")
+  List<ListingEnquiry> findInquirerUnreadCounts(int userId);
+
+  @Query("{'listingId': ?0}")
   List<ListingEnquiry> findByListingId(String listingId);
 }

--- a/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
@@ -295,6 +295,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     String activeSessionToken =
         (String) redisTemplate.opsForValue().get("active_session:" + userEmail);
 
-    return activeSessionToken != null; // If found, user has an active session
+    return activeSessionToken != null;
   }
 }

--- a/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/AuthenticationServiceImpl.java
@@ -1,4 +1,4 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.config.JwtService;
@@ -239,8 +239,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         logger.info("Access token blacklisted and session cleared for user: {}", userEmail);
       }
     } catch (DataAccessException exception) {
-      logger.warn(
-          "Error during logout cleanup for user {}: {}", userEmail, exception.getMessage());
+      logger.warn("Error during logout cleanup for user {}: {}", userEmail, exception.getMessage());
     }
 
     if (refreshToken != null) {

--- a/src/main/java/com/codeplanks/home360/service/EnquiryMessageService.java
+++ b/src/main/java/com/codeplanks/home360/service/EnquiryMessageService.java
@@ -1,4 +1,4 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listingEnquiries.EnquiryMessage;
@@ -6,7 +6,8 @@ import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReply
 import com.codeplanks.home360.domain.listingEnquiries.PaginatedListingEnquiriesChat;
 
 public interface EnquiryMessageService {
-  EnquiryMessage addReplyMessage(String enquiryId, ListingEnquiryMessageReplyDTO reply, int senderId);
+  EnquiryMessage addReplyMessage(
+      String enquiryId, ListingEnquiryMessageReplyDTO reply, int senderId);
 
   PaginatedListingEnquiriesChat getEnquiryMessages(String enquiryId, int page, int size);
 }

--- a/src/main/java/com/codeplanks/home360/service/EnquiryMessageService.java
+++ b/src/main/java/com/codeplanks/home360/service/EnquiryMessageService.java
@@ -1,0 +1,12 @@
+/* (C)2025 */
+package com.codeplanks.home360.service;
+
+import com.codeplanks.home360.domain.listingEnquiries.EnquiryMessage;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReplyDTO;
+import com.codeplanks.home360.domain.listingEnquiries.PaginatedListingEnquiriesChat;
+
+public interface EnquiryMessageService {
+  EnquiryMessage addReplyMessage(String enquiryId, ListingEnquiryMessageReplyDTO reply, int senderId);
+
+  PaginatedListingEnquiriesChat getEnquiryMessages(String enquiryId, int page, int size);
+}

--- a/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
@@ -1,0 +1,85 @@
+/* (C)2025 */
+package com.codeplanks.home360.service;
+
+import com.codeplanks.home360.domain.listingEnquiries.EnquiryMessage;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReplyDTO;
+import com.codeplanks.home360.domain.listingEnquiries.PaginatedListingEnquiriesChat;
+import com.codeplanks.home360.repository.EnquiryMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Validated
+public class EnquiryMessageServiceImpl implements EnquiryMessageService {
+
+  private final EnquiryMessageRepository enquiryMessageRepository;
+  private final ListingEnquiryService listingEnquiryService;
+  private final MongoTemplate mongoTemplate;
+
+  private static final Logger logger = LoggerFactory.getLogger(EnquiryMessageServiceImpl.class);
+
+  @Override
+  public EnquiryMessage addReplyMessage(
+      String enquiryId, ListingEnquiryMessageReplyDTO reply, int senderId) {
+    if (reply == null) {
+      throw new IllegalArgumentException("Message reply cannot be null or blank");
+    }
+
+    ListingEnquiry enquiry = listingEnquiryService.getListingEnquiryById(enquiryId);
+
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    EnquiryMessage newMessage =
+        EnquiryMessage.builder()
+            .enquiryId(enquiryId)
+            .senderId(senderId)
+            .receiverId(
+                senderId == enquiry.getAgentId() ? enquiry.getUserId() : enquiry.getAgentId())
+            .content(reply.getContent())
+            .createdAt(now)
+            .build();
+
+    EnquiryMessage savedMessage = enquiryMessageRepository.save(newMessage);
+
+    // 3. Atomic Update of lastMessageAt in the parent enquiry
+    Query query = new Query(Criteria.where("_id").is(enquiryId));
+    Update update = new Update().set("lastMessageAt", now);
+    mongoTemplate.updateFirst(query, update, ListingEnquiry.class);
+
+    logger.info("New message added to enquiry {}: {}", enquiryId, savedMessage.getId());
+
+    return savedMessage;
+  }
+
+  @Override
+  public PaginatedListingEnquiriesChat getEnquiryMessages(String enquiryId, int page, int size) {
+    
+    listingEnquiryService.getListingEnquiryById(enquiryId);
+
+    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "createdAt");
+    Page<EnquiryMessage> messages = enquiryMessageRepository.findByEnquiryId(enquiryId, pageable);
+
+    return PaginatedListingEnquiriesChat.builder()
+        .items(messages.getContent())
+        .currentPage(messages.getNumber())
+        .totalItems(messages.getTotalElements())
+        .totalPages(messages.getTotalPages())
+        .hasNext(messages.hasNext())
+        .build();
+  }
+}

--- a/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
@@ -85,7 +85,7 @@ public class EnquiryMessageServiceImpl implements EnquiryMessageService {
 
     return PaginatedListingEnquiriesChat.builder()
         .items(messages.getContent())
-        .currentPage(messages.getNumber()+ 1)
+        .currentPage(messages.getNumber() + 1)
         .totalItems(messages.getTotalElements())
         .totalPages(messages.getTotalPages())
         .hasNext(messages.hasNext())

--- a/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
@@ -55,9 +55,18 @@ public class EnquiryMessageServiceImpl implements EnquiryMessageService {
 
     EnquiryMessage savedMessage = enquiryMessageRepository.save(newMessage);
 
-    // 3. Atomic Update of lastMessageAt in the parent enquiry
+    // 3. Atomic Update of lastMessageAt and increment recipient's unread count
     Query query = new Query(Criteria.where("_id").is(enquiryId));
     Update update = new Update().set("lastMessageAt", now);
+
+    if (senderId == enquiry.getAgentId()) {
+      update.inc("unreadCountByInquirer", 1);
+      update.set("unreadCountByAgent", 0); // Sender is reading/viewing the chat
+    } else if (senderId == enquiry.getUserId()) {
+      update.inc("unreadCountByAgent", 1);
+      update.set("unreadCountByInquirer", 0); // Sender is reading/viewing the chat
+    }
+
     mongoTemplate.updateFirst(query, update, ListingEnquiry.class);
 
     logger.info("New message added to enquiry {}: {}", enquiryId, savedMessage.getId());
@@ -67,15 +76,16 @@ public class EnquiryMessageServiceImpl implements EnquiryMessageService {
 
   @Override
   public PaginatedListingEnquiriesChat getEnquiryMessages(String enquiryId, int page, int size) {
+    ListingEnquiry enquiry = listingEnquiryService.getListingEnquiryById(enquiryId);
 
-    listingEnquiryService.getListingEnquiryById(enquiryId);
+    listingEnquiryService.markEnquiryAsRead(enquiryId);
 
     Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "createdAt");
     Page<EnquiryMessage> messages = enquiryMessageRepository.findByEnquiryId(enquiryId, pageable);
 
     return PaginatedListingEnquiriesChat.builder()
         .items(messages.getContent())
-        .currentPage(messages.getNumber())
+        .currentPage(messages.getNumber()+ 1)
         .totalItems(messages.getTotalElements())
         .totalPages(messages.getTotalPages())
         .hasNext(messages.hasNext())

--- a/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/EnquiryMessageServiceImpl.java
@@ -1,4 +1,4 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listingEnquiries.EnquiryMessage;
@@ -6,6 +6,8 @@ import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReplyDTO;
 import com.codeplanks.home360.domain.listingEnquiries.PaginatedListingEnquiriesChat;
 import com.codeplanks.home360.repository.EnquiryMessageRepository;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,9 +21,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
-
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -68,7 +67,7 @@ public class EnquiryMessageServiceImpl implements EnquiryMessageService {
 
   @Override
   public PaginatedListingEnquiriesChat getEnquiryMessages(String enquiryId, int page, int size) {
-    
+
     listingEnquiryService.getListingEnquiryById(enquiryId);
 
     Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "createdAt");

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
@@ -3,6 +3,7 @@ package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listingEnquiries.*;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public interface ListingEnquiryService {
   ListingEnquiry makeEnquiry(ListingEnquiryDTO enquiryRequest);
@@ -13,9 +14,6 @@ public interface ListingEnquiryService {
   ListingEnquiry getListingEnquiryById(String enquiryMessageId);
 
   Boolean markMessageAsRead(String enquiryMessageId);
-
-  ListingEnquiryMessageReply addReplyMessage(
-      String enquiryId, ListingEnquiryMessageReplyDTO reply, int senderId);
 
   List<ListingEnquiry> getEnquiriesByListingId(String listingId);
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
@@ -8,11 +8,13 @@ public interface ListingEnquiryService {
   ListingEnquiry makeEnquiry(ListingEnquiryDTO enquiryRequest);
 
   PaginatedListingEnquiriesResponse getListingEnquiries(
-      int page, int size, Integer senderId, int agentId);
+      int page, int size, Integer senderId, int agentId, EnquiryStatus status);
 
   ListingEnquiry getListingEnquiryById(String enquiryMessageId);
 
   Boolean markEnquiryAsRead(String enquiryMessageId);
 
   List<ListingEnquiry> getEnquiriesByListingId(String listingId);
+
+  Integer getTotalUnreadCount();
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
@@ -1,4 +1,4 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listingEnquiries.*;

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryService.java
@@ -3,7 +3,6 @@ package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listingEnquiries.*;
 import java.util.List;
-import org.springframework.data.domain.Page;
 
 public interface ListingEnquiryService {
   ListingEnquiry makeEnquiry(ListingEnquiryDTO enquiryRequest);
@@ -13,7 +12,7 @@ public interface ListingEnquiryService {
 
   ListingEnquiry getListingEnquiryById(String enquiryMessageId);
 
-  Boolean markMessageAsRead(String enquiryMessageId);
+  Boolean markEnquiryAsRead(String enquiryMessageId);
 
   List<ListingEnquiry> getEnquiriesByListingId(String listingId);
 }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -5,14 +5,21 @@ import com.codeplanks.home360.domain.listing.Listing;
 import com.codeplanks.home360.domain.listingEnquiries.*;
 import com.codeplanks.home360.exception.NotFoundException;
 import com.codeplanks.home360.repository.ListingEnquiryRepository;
+import com.codeplanks.home360.repository.EnquiryMessageRepository;
 import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.mongodb.client.result.UpdateResult;
-import java.time.LocalDateTime;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
@@ -34,16 +41,20 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   private final ListingEnquiryRepository listingEnquiryRepository;
+  private final EnquiryMessageRepository enquiryMessageRepository;
   private final MongoTemplate mongoTemplate;
   private final UserServiceImpl userService;
   private final ListingServiceImpl listingService;
   private final AuthenticationUtils authenticationUtils;
 
+  private static final Logger logger = LoggerFactory.getLogger(ListingEnquiryServiceImpl.class);
+
   @Caching(
-      evict = {
-        @CacheEvict(value = "enquiriesByListingId", key = "#enquiryRequest.listingId"),
-        @CacheEvict(value = "agentListingEnquiries", key = "#enquiryRequest.agentId + '::*'")
-      })
+          evict = {
+                  @CacheEvict(value = "enquiriesByListingId", key = "#enquiryRequest.listingId"),
+                  @CacheEvict(value = "agentListingEnquiries", key = "#enquiryRequest.agentId + " +
+                          "'::*'")
+          })
   @Override
   public ListingEnquiry makeEnquiry(ListingEnquiryDTO enquiryRequest) {
     if (authenticationUtils.isAuthenticated()) {
@@ -53,44 +64,46 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
 
     listingService.findListingById(enquiryRequest.getListingId());
 
-    enquiryRequest.setCreatedAt(LocalDateTime.now());
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    enquiryRequest.setCreatedAt(now);
     ListingEnquiry newListingEnquiry =
-        ListingEnquiry.builder()
-            .firstName(enquiryRequest.getFirstName())
-            .lastName(enquiryRequest.getLastName())
-            .email(enquiryRequest.getEmail())
-            .phoneNumber(enquiryRequest.getPhoneNumber())
-            .location(enquiryRequest.getLocation())
-            .salutation(enquiryRequest.getSalutation())
-            .message(enquiryRequest.getMessage())
-            .employmentStatus(enquiryRequest.getEmploymentStatus())
-            .pets(enquiryRequest.getPets())
-            .commercialPurpose(enquiryRequest.getCommercialPurpose())
-            .listingId(enquiryRequest.getListingId())
-            .agentId(enquiryRequest.getAgentId())
-            .userId(enquiryRequest.getUserId())
-            .createdAt(LocalDateTime.now())
-            .build();
+            ListingEnquiry.builder()
+                    .firstName(enquiryRequest.getFirstName())
+                    .lastName(enquiryRequest.getLastName())
+                    .email(enquiryRequest.getEmail())
+                    .phoneNumber(enquiryRequest.getPhoneNumber())
+                    .location(enquiryRequest.getLocation())
+                    .salutation(enquiryRequest.getSalutation())
+                    .message(enquiryRequest.getMessage())
+                    .employmentStatus(enquiryRequest.getEmploymentStatus())
+                    .pets(enquiryRequest.getPets())
+                    .commercialPurpose(enquiryRequest.getCommercialPurpose())
+                    .listingId(enquiryRequest.getListingId())
+                    .agentId(enquiryRequest.getAgentId())
+                    .userId(enquiryRequest.getUserId())
+                    .createdAt(now)
+                    .lastMessageAt(now)
+                    .build();
     return listingEnquiryRepository.save(newListingEnquiry);
   }
 
   @Cacheable(
-      value = "agentListingEnquiries",
-      key =
-          "#agentId + '::senderId::' + #senderId + '::page::' + #page + '::size::' + #size")
+          value = "agentListingEnquiries",
+          key =
+                  "#agentId + '::senderId::' + #senderId + '::page::' + #page + '::size::' + #size")
   @Override
   public PaginatedListingEnquiriesResponse getListingEnquiries(
-      int page, int size, Integer senderId, int agentId) {
-    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "created_at");
+          int page, int size, Integer senderId, int agentId) {
+    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
     Page<ListingEnquiry> agentListingEnquiries =
-        listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable);
+            listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable);
     return PaginatedListingEnquiriesResponse.<ListingEnquiry>builder()
-        .currentPage(agentListingEnquiries.getNumber() + 1)
-        .totalItems(agentListingEnquiries.getTotalElements())
-        .totalPages(agentListingEnquiries.getTotalPages())
-        .items(agentListingEnquiries.getContent())
-        .hasNext(agentListingEnquiries.hasNext())
-        .build();
+            .currentPage(agentListingEnquiries.getNumber() + 1)
+            .totalItems(agentListingEnquiries.getTotalElements())
+            .totalPages(agentListingEnquiries.getTotalPages())
+            .items(agentListingEnquiries.getContent())
+            .hasNext(agentListingEnquiries.hasNext())
+            .build();
   }
 
   @Cacheable(value = "listingEnquiry", key = "#enquiryMessageId")
@@ -100,11 +113,11 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
       throw new IllegalArgumentException("Enquiry ID cannot be null or empty");
     }
     ListingEnquiry listingEnquiry =
-        listingEnquiryRepository
-            .findById(enquiryMessageId)
-            .orElseThrow(() -> new NotFoundException("Listing enquiry not found"));
+            listingEnquiryRepository
+                    .findById(enquiryMessageId)
+                    .orElseThrow(() -> new NotFoundException("Listing enquiry not found"));
 
-    validateUserAuthorization(listingEnquiry);
+    validateUserAuthorization(listingEnquiry, userService.extractUserId());
     return listingEnquiry;
   }
 
@@ -114,51 +127,9 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     validateEnquiryExists(query);
     ListingEnquiry listingEnquiry = mongoTemplate.findOne(query, ListingEnquiry.class);
     if (listingEnquiry != null) {
-      validateUserAuthorization(listingEnquiry);
+      validateUserAuthorization(listingEnquiry, userService.extractUserId());
     }
     return updateMessageAsRead(query);
-  }
-
-  @Caching(evict = {@CacheEvict(value = "listingEnquiry", key = "#enquiryMessageId")})
-  @Override
-  public ListingEnquiryMessageReply addReplyMessage(
-      String enquiryMessageId, ListingEnquiryMessageReplyDTO reply, int senderId) {
-    if (reply == null) {
-      throw new IllegalArgumentException("Message reply cannot be null or blank");
-    }
-
-    // 1. Create the reply object
-    ListingEnquiryMessageReply newReply =
-        ListingEnquiryMessageReply.builder()
-            .agentId(reply.getAgentId())
-            .enquirerId(reply.getEnquirerId())
-            .senderId(senderId)
-            .content(reply.getContent())
-            .id(UUID.randomUUID().toString())
-            .createdAt(LocalDateTime.now())
-            .build();
-
-    // 2. Create a single, atomic, authorizing query
-    Query query =
-        new Query(
-            Criteria.where("_id")
-                .is(enquiryMessageId)
-                .orOperator(
-                    Criteria.where("agentId").is(senderId), Criteria.where("userId").is(senderId)));
-
-    // 3. Create the update operation
-    Update update = new Update().push("replies", newReply);
-
-    // 4. Execute the update
-    UpdateResult result = mongoTemplate.updateFirst(query, update, ListingEnquiry.class);
-
-    // 5. Check if the update was successful
-    if (result.getMatchedCount() == 0) {
-      // This means either the enquiry doesn't exist OR the user is not authorized
-      throw new AccessDeniedException("Enquiry not found or you are not authorized to reply to it.");
-    }
-
-    return newReply;
   }
 
   @Cacheable(value = "enquiriesByListingId", key = "#listingId")
@@ -183,13 +154,12 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     }
   }
 
-  private void validateUserAuthorization(ListingEnquiry listingEnquiry) {
-    Integer userId = userService.extractUserId();
+  private void validateUserAuthorization(ListingEnquiry listingEnquiry, Integer userId) {
     boolean isAgent = userId != null && userId.equals(listingEnquiry.getAgentId());
     boolean isInquirer =
-        userId != null
-            && listingEnquiry.getUserId() != null
-            && userId.equals(listingEnquiry.getUserId());
+            userId != null
+                    && listingEnquiry.getUserId() != null
+                    && userId.equals(listingEnquiry.getUserId());
     if (!isAgent && !isInquirer) {
       throw new AccessDeniedException("Forbidden. You're not authorized to access this data");
     }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -39,7 +39,6 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   private final ListingServiceImpl listingService;
   private final AuthenticationUtils authenticationUtils;
 
-
   @Caching(
       evict = {
         @CacheEvict(value = "enquiriesByListingId", key = "#enquiryRequest.listingId"),
@@ -83,7 +82,8 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   @Cacheable(
       value = "agentListingEnquiries",
       key =
-          "#agentId + '::senderId::' + #senderId + '::status::' + #status + '::page::' + #page + '::size::' + #size")
+          "#agentId + '::senderId::' + #senderId + '::status::' + #status + '::page::' + #page +"
+              + " '::size::' + #size")
   @Override
   public PaginatedListingEnquiriesResponse getListingEnquiries(
       int page, int size, Integer senderId, int agentId, EnquiryStatus status) {
@@ -184,6 +184,5 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     if (!isAgent && !isInquirer) {
       throw new AccessDeniedException("Forbidden. You're not authorized to access this data");
     }
-  }}
-
-
+  }
+}

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -17,9 +17,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
@@ -122,7 +120,7 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   }
 
   @Override
-  public Boolean markMessageAsRead(String enquiryMessageId) {
+  public Boolean markEnquiryAsRead(String enquiryMessageId) {
     Query query = createQuery(enquiryMessageId);
     validateEnquiryExists(query);
     ListingEnquiry listingEnquiry = mongoTemplate.findOne(query, ListingEnquiry.class);

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -1,19 +1,17 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.service;
 
 import com.codeplanks.home360.domain.listing.Listing;
 import com.codeplanks.home360.domain.listingEnquiries.*;
 import com.codeplanks.home360.exception.NotFoundException;
-import com.codeplanks.home360.repository.ListingEnquiryRepository;
 import com.codeplanks.home360.repository.EnquiryMessageRepository;
+import com.codeplanks.home360.repository.ListingEnquiryRepository;
 import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.mongodb.client.result.UpdateResult;
-
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
-
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,11 +46,10 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   private static final Logger logger = LoggerFactory.getLogger(ListingEnquiryServiceImpl.class);
 
   @Caching(
-          evict = {
-                  @CacheEvict(value = "enquiriesByListingId", key = "#enquiryRequest.listingId"),
-                  @CacheEvict(value = "agentListingEnquiries", key = "#enquiryRequest.agentId + " +
-                          "'::*'")
-          })
+      evict = {
+        @CacheEvict(value = "enquiriesByListingId", key = "#enquiryRequest.listingId"),
+        @CacheEvict(value = "agentListingEnquiries", key = "#enquiryRequest.agentId + " + "'::*'")
+      })
   @Override
   public ListingEnquiry makeEnquiry(ListingEnquiryDTO enquiryRequest) {
     if (authenticationUtils.isAuthenticated()) {
@@ -65,43 +62,42 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
     enquiryRequest.setCreatedAt(now);
     ListingEnquiry newListingEnquiry =
-            ListingEnquiry.builder()
-                    .firstName(enquiryRequest.getFirstName())
-                    .lastName(enquiryRequest.getLastName())
-                    .email(enquiryRequest.getEmail())
-                    .phoneNumber(enquiryRequest.getPhoneNumber())
-                    .location(enquiryRequest.getLocation())
-                    .salutation(enquiryRequest.getSalutation())
-                    .message(enquiryRequest.getMessage())
-                    .employmentStatus(enquiryRequest.getEmploymentStatus())
-                    .pets(enquiryRequest.getPets())
-                    .commercialPurpose(enquiryRequest.getCommercialPurpose())
-                    .listingId(enquiryRequest.getListingId())
-                    .agentId(enquiryRequest.getAgentId())
-                    .userId(enquiryRequest.getUserId())
-                    .createdAt(now)
-                    .lastMessageAt(now)
-                    .build();
+        ListingEnquiry.builder()
+            .firstName(enquiryRequest.getFirstName())
+            .lastName(enquiryRequest.getLastName())
+            .email(enquiryRequest.getEmail())
+            .phoneNumber(enquiryRequest.getPhoneNumber())
+            .location(enquiryRequest.getLocation())
+            .salutation(enquiryRequest.getSalutation())
+            .message(enquiryRequest.getMessage())
+            .employmentStatus(enquiryRequest.getEmploymentStatus())
+            .pets(enquiryRequest.getPets())
+            .commercialPurpose(enquiryRequest.getCommercialPurpose())
+            .listingId(enquiryRequest.getListingId())
+            .agentId(enquiryRequest.getAgentId())
+            .userId(enquiryRequest.getUserId())
+            .createdAt(now)
+            .lastMessageAt(now)
+            .build();
     return listingEnquiryRepository.save(newListingEnquiry);
   }
 
   @Cacheable(
-          value = "agentListingEnquiries",
-          key =
-                  "#agentId + '::senderId::' + #senderId + '::page::' + #page + '::size::' + #size")
+      value = "agentListingEnquiries",
+      key = "#agentId + '::senderId::' + #senderId + '::page::' + #page + '::size::' + #size")
   @Override
   public PaginatedListingEnquiriesResponse getListingEnquiries(
-          int page, int size, Integer senderId, int agentId) {
+      int page, int size, Integer senderId, int agentId) {
     Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
     Page<ListingEnquiry> agentListingEnquiries =
-            listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable);
+        listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable);
     return PaginatedListingEnquiriesResponse.<ListingEnquiry>builder()
-            .currentPage(agentListingEnquiries.getNumber() + 1)
-            .totalItems(agentListingEnquiries.getTotalElements())
-            .totalPages(agentListingEnquiries.getTotalPages())
-            .items(agentListingEnquiries.getContent())
-            .hasNext(agentListingEnquiries.hasNext())
-            .build();
+        .currentPage(agentListingEnquiries.getNumber() + 1)
+        .totalItems(agentListingEnquiries.getTotalElements())
+        .totalPages(agentListingEnquiries.getTotalPages())
+        .items(agentListingEnquiries.getContent())
+        .hasNext(agentListingEnquiries.hasNext())
+        .build();
   }
 
   @Cacheable(value = "listingEnquiry", key = "#enquiryMessageId")
@@ -111,9 +107,9 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
       throw new IllegalArgumentException("Enquiry ID cannot be null or empty");
     }
     ListingEnquiry listingEnquiry =
-            listingEnquiryRepository
-                    .findById(enquiryMessageId)
-                    .orElseThrow(() -> new NotFoundException("Listing enquiry not found"));
+        listingEnquiryRepository
+            .findById(enquiryMessageId)
+            .orElseThrow(() -> new NotFoundException("Listing enquiry not found"));
 
     validateUserAuthorization(listingEnquiry, userService.extractUserId());
     return listingEnquiry;
@@ -155,9 +151,9 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   private void validateUserAuthorization(ListingEnquiry listingEnquiry, Integer userId) {
     boolean isAgent = userId != null && userId.equals(listingEnquiry.getAgentId());
     boolean isInquirer =
-            userId != null
-                    && listingEnquiry.getUserId() != null
-                    && userId.equals(listingEnquiry.getUserId());
+        userId != null
+            && listingEnquiry.getUserId() != null
+            && userId.equals(listingEnquiry.getUserId());
     if (!isAgent && !isInquirer) {
       throw new AccessDeniedException("Forbidden. You're not authorized to access this data");
     }

--- a/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
+++ b/src/main/java/com/codeplanks/home360/service/ListingEnquiryServiceImpl.java
@@ -4,7 +4,6 @@ package com.codeplanks.home360.service;
 import com.codeplanks.home360.domain.listing.Listing;
 import com.codeplanks.home360.domain.listingEnquiries.*;
 import com.codeplanks.home360.exception.NotFoundException;
-import com.codeplanks.home360.repository.EnquiryMessageRepository;
 import com.codeplanks.home360.repository.ListingEnquiryRepository;
 import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.mongodb.client.result.UpdateResult;
@@ -13,8 +12,6 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -37,13 +34,11 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   private final ListingEnquiryRepository listingEnquiryRepository;
-  private final EnquiryMessageRepository enquiryMessageRepository;
   private final MongoTemplate mongoTemplate;
   private final UserServiceImpl userService;
   private final ListingServiceImpl listingService;
   private final AuthenticationUtils authenticationUtils;
 
-  private static final Logger logger = LoggerFactory.getLogger(ListingEnquiryServiceImpl.class);
 
   @Caching(
       evict = {
@@ -78,19 +73,23 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
             .userId(enquiryRequest.getUserId())
             .createdAt(now)
             .lastMessageAt(now)
+            .unreadCountByAgent(1)
+            .unreadCountByInquirer(0)
+            .status(EnquiryStatus.PENDING)
             .build();
     return listingEnquiryRepository.save(newListingEnquiry);
   }
 
   @Cacheable(
       value = "agentListingEnquiries",
-      key = "#agentId + '::senderId::' + #senderId + '::page::' + #page + '::size::' + #size")
+      key =
+          "#agentId + '::senderId::' + #senderId + '::status::' + #status + '::page::' + #page + '::size::' + #size")
   @Override
   public PaginatedListingEnquiriesResponse getListingEnquiries(
-      int page, int size, Integer senderId, int agentId) {
+      int page, int size, Integer senderId, int agentId, EnquiryStatus status) {
     Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
     Page<ListingEnquiry> agentListingEnquiries =
-        listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable);
+        listingEnquiryRepository.findListingEnquiries(agentId, senderId, status, pageable);
     return PaginatedListingEnquiriesResponse.<ListingEnquiry>builder()
         .currentPage(agentListingEnquiries.getNumber() + 1)
         .totalItems(agentListingEnquiries.getTotalElements())
@@ -100,7 +99,9 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
         .build();
   }
 
-  @Cacheable(value = "listingEnquiry", key = "#enquiryMessageId")
+  @Cacheable(
+      value = "listingEnquiry",
+      key = "#enquiryMessageId + '::' + #root.target.userService.extractUserId()")
   @Override
   public ListingEnquiry getListingEnquiryById(String enquiryMessageId) {
     if (enquiryMessageId == null) {
@@ -116,17 +117,32 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
   }
 
   @Override
-  public Boolean markEnquiryAsRead(String enquiryMessageId) {
-    Query query = createQuery(enquiryMessageId);
-    validateEnquiryExists(query);
-    ListingEnquiry listingEnquiry = mongoTemplate.findOne(query, ListingEnquiry.class);
-    if (listingEnquiry != null) {
-      validateUserAuthorization(listingEnquiry, userService.extractUserId());
+  public Boolean markEnquiryAsRead(String enquiryId) {
+    ListingEnquiry enquiry = getListingEnquiryById(enquiryId);
+    Integer userId = userService.extractUserId();
+
+    Query query = new Query(Criteria.where("_id").is(enquiryId));
+    Update update = new Update();
+
+    if (Objects.equals(userId, enquiry.getAgentId())) {
+      update.set("unreadCountByAgent", 0);
+      // Transition from PENDING to ACTIVE when agent acknowledges
+      if (enquiry.getStatus() == EnquiryStatus.PENDING) {
+        update.set("status", EnquiryStatus.ACTIVE);
+      }
+    } else if (Objects.equals(userId, enquiry.getUserId())) {
+      update.set("unreadCountByInquirer", 0);
+    } else {
+      throw new AccessDeniedException("You are not authorized to mark this conversation as read");
     }
-    return updateMessageAsRead(query);
+
+    UpdateResult updateResult = mongoTemplate.updateFirst(query, update, ListingEnquiry.class);
+    return updateResult.getModifiedCount() > 0;
   }
 
-  @Cacheable(value = "enquiriesByListingId", key = "#listingId")
+  @Cacheable(
+      value = "enquiriesByListingId",
+      key = "#listingId + '::' + #root.target.userService.extractUserId()")
   @Override
   public List<ListingEnquiry> getEnquiriesByListingId(String listingId) {
     Integer userId = userService.extractUserId();
@@ -137,15 +153,26 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     return listingEnquiryRepository.findByListingId(listingId);
   }
 
-  private Query createQuery(String enquiryMessageId) {
-    return new Query(Criteria.where("_id").is(enquiryMessageId));
-  }
-
-  private void validateEnquiryExists(Query query) {
-    boolean exists = mongoTemplate.exists(query, ListingEnquiry.class);
-    if (!exists) {
-      throw new NotFoundException("Listing enquiry with the given ID was not found");
+  @Override
+  public Integer getTotalUnreadCount() {
+    Integer userId = userService.extractUserId();
+    if (userId == null) {
+      return 0;
     }
+
+    // Sum unread messages as an Agent
+    int agentUnread =
+        listingEnquiryRepository.findAgentUnreadCounts(userId).stream()
+            .mapToInt(ListingEnquiry::getUnreadCountByAgent)
+            .sum();
+
+    // Sum unread messages as an Inquirer
+    int inquirerUnread =
+        listingEnquiryRepository.findInquirerUnreadCounts(userId).stream()
+            .mapToInt(ListingEnquiry::getUnreadCountByInquirer)
+            .sum();
+
+    return agentUnread + inquirerUnread;
   }
 
   private void validateUserAuthorization(ListingEnquiry listingEnquiry, Integer userId) {
@@ -157,11 +184,6 @@ public class ListingEnquiryServiceImpl implements ListingEnquiryService {
     if (!isAgent && !isInquirer) {
       throw new AccessDeniedException("Forbidden. You're not authorized to access this data");
     }
-  }
+  }}
 
-  private Boolean updateMessageAsRead(Query query) {
-    Update update = new Update().set("read", true);
-    UpdateResult updateResult = mongoTemplate.updateFirst(query, update, ListingEnquiry.class);
-    return updateResult.getModifiedCount() > 0;
-  }
-}
+

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketAuthenticationInterceptor.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketAuthenticationInterceptor.java
@@ -1,4 +1,4 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.websocket;
 
 import com.codeplanks.home360.config.JwtService;
@@ -62,8 +62,7 @@ public class WebSocketAuthenticationInterceptor implements ChannelInterceptor {
       throw new BadCredentialsException("Invalid JWT");
     }
 
-    return new UsernamePasswordAuthenticationToken(
-        userDetails, null, userDetails.getAuthorities());
+    return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
   }
 
   private Message<?> handleConnect(StompHeaderAccessor accessor, Message<?> message) {

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketAuthenticationInterceptor.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketAuthenticationInterceptor.java
@@ -83,7 +83,7 @@ public class WebSocketAuthenticationInterceptor implements ChannelInterceptor {
       return message;
     } catch (Exception ex) {
       logger.error("WebSocket authentication failed: {}", ex.getMessage());
-      throw new MessagingException("Authentication failed: " + ex.getMessage());
+      throw new MessagingException("Authentication failed");
     }
   }
 }

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketConfig.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketConfig.java
@@ -89,7 +89,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         if (accessor != null && accessor.getCommand() != null) {
           logger.info("Inbound STOMP command: {} destination={}",
                   accessor.getCommand(), accessor.getDestination());
-          logger.info("message being sent: {}", message.getPayload());
         }
         return message;
       }

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketConfig.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketConfig.java
@@ -31,16 +31,19 @@ import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   private final WebSocketAuthenticationInterceptor authenticationInterceptor;
   private final WebSocketSubscriptionAuthorizationInterceptor authorizationInterceptor;
+  private final WebSocketRateLimitingInterceptor rateLimitingInterceptor;
   private final CurrentUserArgumentResolver currentUserArgumentResolver;
   private final WebsocketBrokerProperties websocketBrokerProperties;
 
   public WebSocketConfig(WebSocketAuthenticationInterceptor authenticationInterceptor,
                          WebSocketSubscriptionAuthorizationInterceptor authorizationInterceptor,
+                         WebSocketRateLimitingInterceptor rateLimitingInterceptor,
                          CurrentUserArgumentResolver currentUserArgumentResolver,
                          WebsocketBrokerProperties websocketBrokerProperties) {
 
     this.authenticationInterceptor = authenticationInterceptor;
     this.authorizationInterceptor = authorizationInterceptor;
+    this.rateLimitingInterceptor = rateLimitingInterceptor;
     this.currentUserArgumentResolver = currentUserArgumentResolver;
     this.websocketBrokerProperties = websocketBrokerProperties;
   }
@@ -86,10 +89,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         if (accessor != null && accessor.getCommand() != null) {
           logger.info("Inbound STOMP command: {} destination={}",
                   accessor.getCommand(), accessor.getDestination());
+          logger.info("message being sent: {}", message.getPayload());
         }
         return message;
       }
-    }, authenticationInterceptor, authorizationInterceptor);
+    }, authenticationInterceptor, rateLimitingInterceptor, authorizationInterceptor);
   }
 
   @Override

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketConfig.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketConfig.java
@@ -1,12 +1,10 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.websocket;
 
 import com.codeplanks.home360.config.configProperties.WebsocketBrokerProperties;
 import com.codeplanks.home360.utils.AppConstants;
 import com.codeplanks.home360.validation.CurrentUserArgumentResolver;
-
 import java.util.List;
-
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +23,6 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
 
-
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
@@ -35,11 +32,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   private final CurrentUserArgumentResolver currentUserArgumentResolver;
   private final WebsocketBrokerProperties websocketBrokerProperties;
 
-  public WebSocketConfig(WebSocketAuthenticationInterceptor authenticationInterceptor,
-                         WebSocketSubscriptionAuthorizationInterceptor authorizationInterceptor,
-                         WebSocketRateLimitingInterceptor rateLimitingInterceptor,
-                         CurrentUserArgumentResolver currentUserArgumentResolver,
-                         WebsocketBrokerProperties websocketBrokerProperties) {
+  public WebSocketConfig(
+      WebSocketAuthenticationInterceptor authenticationInterceptor,
+      WebSocketSubscriptionAuthorizationInterceptor authorizationInterceptor,
+      WebSocketRateLimitingInterceptor rateLimitingInterceptor,
+      CurrentUserArgumentResolver currentUserArgumentResolver,
+      WebsocketBrokerProperties websocketBrokerProperties) {
 
     this.authenticationInterceptor = authenticationInterceptor;
     this.authorizationInterceptor = authorizationInterceptor;
@@ -48,30 +46,31 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     this.websocketBrokerProperties = websocketBrokerProperties;
   }
 
-  private static final Logger logger =
-          LoggerFactory.getLogger(WebSocketConfig.class);
+  private static final Logger logger = LoggerFactory.getLogger(WebSocketConfig.class);
 
   @Value("${allowed.origins}")
   private String[] allowedOrigins;
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    registry.addEndpoint(AppConstants.WS_ENDPOINT).setAllowedOriginPatterns(allowedOrigins)
-            .withSockJS();
+    registry
+        .addEndpoint(AppConstants.WS_ENDPOINT)
+        .setAllowedOriginPatterns(allowedOrigins)
+        .withSockJS();
     registry.setErrorHandler(new StompSubProtocolErrorHandler());
   }
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
     config
-            .setApplicationDestinationPrefixes(AppConstants.APP_PREFIX)
-            .enableStompBrokerRelay(AppConstants.TOPIC_PREFIX, "/queue")
-            .setRelayHost(websocketBrokerProperties.relayHost())
-            .setRelayPort(websocketBrokerProperties.brokerPort())
-            .setClientLogin(websocketBrokerProperties.clientLogin())
-            .setClientPasscode(websocketBrokerProperties.clientPasscode())
-            .setSystemLogin(websocketBrokerProperties.clientLogin())
-            .setSystemPasscode(websocketBrokerProperties.clientPasscode());
+        .setApplicationDestinationPrefixes(AppConstants.APP_PREFIX)
+        .enableStompBrokerRelay(AppConstants.TOPIC_PREFIX, "/queue")
+        .setRelayHost(websocketBrokerProperties.relayHost())
+        .setRelayPort(websocketBrokerProperties.brokerPort())
+        .setClientLogin(websocketBrokerProperties.clientLogin())
+        .setClientPasscode(websocketBrokerProperties.clientPasscode())
+        .setSystemLogin(websocketBrokerProperties.clientLogin())
+        .setSystemPasscode(websocketBrokerProperties.clientPasscode());
   }
 
   @Override
@@ -81,28 +80,34 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureClientInboundChannel(ChannelRegistration registration) {
-    registration.interceptors(new ChannelInterceptor() {
-      @Override
-      public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
-        StompHeaderAccessor accessor =
+    registration.interceptors(
+        new ChannelInterceptor() {
+          @Override
+          public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+            StompHeaderAccessor accessor =
                 MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        if (accessor != null && accessor.getCommand() != null) {
-          logger.info("Inbound STOMP command: {} destination={}",
-                  accessor.getCommand(), accessor.getDestination());
-        }
-        return message;
-      }
-    }, authenticationInterceptor, rateLimitingInterceptor, authorizationInterceptor);
+            if (accessor != null && accessor.getCommand() != null) {
+              logger.info(
+                  "Inbound STOMP command: {} destination={}",
+                  accessor.getCommand(),
+                  accessor.getDestination());
+            }
+            return message;
+          }
+        },
+        authenticationInterceptor,
+        rateLimitingInterceptor,
+        authorizationInterceptor);
   }
 
   @Override
   public void configureClientOutboundChannel(ChannelRegistration registration) {
-    registration.interceptors(new ChannelInterceptor() {
-      @Override
-      public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
-        return message;
-      }
-    });
+    registration.interceptors(
+        new ChannelInterceptor() {
+          @Override
+          public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+            return message;
+          }
+        });
   }
-
 }

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketRateLimitingInterceptor.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketRateLimitingInterceptor.java
@@ -1,4 +1,4 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.websocket;
 
 import com.codeplanks.home360.domain.user.AppUser;
@@ -21,7 +21,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WebSocketRateLimitingInterceptor implements ChannelInterceptor {
-  private static final Logger logger = LoggerFactory.getLogger(WebSocketRateLimitingInterceptor.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(WebSocketRateLimitingInterceptor.class);
   private final Map<String, Bucket> bucketCache = new ConcurrentHashMap<>();
 
   @Override
@@ -33,7 +34,8 @@ public class WebSocketRateLimitingInterceptor implements ChannelInterceptor {
       return message;
     }
 
-    if (StompCommand.SEND.equals(accessor.getCommand()) || StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+    if (StompCommand.SEND.equals(accessor.getCommand())
+        || StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
       Authentication authentication = (Authentication) accessor.getUser();
       if (authentication != null && authentication.getPrincipal() instanceof AppUser user) {
         String userId = user.getId().toString();
@@ -51,7 +53,9 @@ public class WebSocketRateLimitingInterceptor implements ChannelInterceptor {
 
   private Bucket createNewBucket() {
     return Bucket.builder()
-        .addLimit(limit -> limit.capacity(100).refillGreedy(100, Duration.ofMinutes(1)).initialTokens(100))
+        .addLimit(
+            limit ->
+                limit.capacity(100).refillGreedy(100, Duration.ofMinutes(1)).initialTokens(100))
         .build();
   }
 }

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketRateLimitingInterceptor.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketRateLimitingInterceptor.java
@@ -2,10 +2,10 @@
 package com.codeplanks.home360.websocket;
 
 import com.codeplanks.home360.domain.user.AppUser;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bucket;
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.NonNull;
@@ -23,7 +23,10 @@ import org.springframework.stereotype.Component;
 public class WebSocketRateLimitingInterceptor implements ChannelInterceptor {
   private static final Logger logger =
       LoggerFactory.getLogger(WebSocketRateLimitingInterceptor.class);
-  private final Map<String, Bucket> bucketCache = new ConcurrentHashMap<>();
+
+  // Expire after 10 minutes of inactivity and cap at 10,000 entries to prevent memory leaks
+  private final Cache<String, Bucket> bucketCache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(10)).maximumSize(10000).build();
 
   @Override
   public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
@@ -39,9 +42,9 @@ public class WebSocketRateLimitingInterceptor implements ChannelInterceptor {
       Authentication authentication = (Authentication) accessor.getUser();
       if (authentication != null && authentication.getPrincipal() instanceof AppUser user) {
         String userId = user.getId().toString();
-        Bucket bucket = bucketCache.computeIfAbsent(userId, k -> createNewBucket());
+        Bucket bucket = bucketCache.get(userId, k -> createNewBucket());
 
-        if (!bucket.tryConsume(1)) {
+        if (bucket != null && !bucket.tryConsume(1)) {
           logger.warn("WebSocket rate limit exceeded for user: {}", user.getEmail());
           throw new MessagingException("Too many messages. Please slow down.");
         }

--- a/src/main/java/com/codeplanks/home360/websocket/WebSocketRateLimitingInterceptor.java
+++ b/src/main/java/com/codeplanks/home360/websocket/WebSocketRateLimitingInterceptor.java
@@ -1,0 +1,57 @@
+/* (C)2025 */
+package com.codeplanks.home360.websocket;
+
+import com.codeplanks.home360.domain.user.AppUser;
+import io.github.bucket4j.Bucket;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebSocketRateLimitingInterceptor implements ChannelInterceptor {
+  private static final Logger logger = LoggerFactory.getLogger(WebSocketRateLimitingInterceptor.class);
+  private final Map<String, Bucket> bucketCache = new ConcurrentHashMap<>();
+
+  @Override
+  public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+    StompHeaderAccessor accessor =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+    if (accessor == null || accessor.getCommand() == null) {
+      return message;
+    }
+
+    if (StompCommand.SEND.equals(accessor.getCommand()) || StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+      Authentication authentication = (Authentication) accessor.getUser();
+      if (authentication != null && authentication.getPrincipal() instanceof AppUser user) {
+        String userId = user.getId().toString();
+        Bucket bucket = bucketCache.computeIfAbsent(userId, k -> createNewBucket());
+
+        if (!bucket.tryConsume(1)) {
+          logger.warn("WebSocket rate limit exceeded for user: {}", user.getEmail());
+          throw new MessagingException("Too many messages. Please slow down.");
+        }
+      }
+    }
+
+    return message;
+  }
+
+  private Bucket createNewBucket() {
+    return Bucket.builder()
+        .addLimit(limit -> limit.capacity(100).refillGreedy(100, Duration.ofMinutes(1)).initialTokens(100))
+        .build();
+  }
+}

--- a/src/test/java/com/codeplanks/home360/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeplanks/home360/repository/UserRepositoryTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.codeplanks.home360.domain.user.AppUser;
 import com.codeplanks.home360.domain.user.Role;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,8 +42,8 @@ class UserRepositoryTest {
             .phoneNumber("09021234567")
             .address("221B, Baker street, London")
             .password(userPassword)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now(ZoneOffset.UTC))
+            .updatedAt(ZonedDateTime.now(ZoneOffset.UTC))
             .build();
   }
 

--- a/src/test/java/com/codeplanks/home360/repository/VerificationTokenRepositoryTest.java
+++ b/src/test/java/com/codeplanks/home360/repository/VerificationTokenRepositoryTest.java
@@ -8,6 +8,8 @@ import com.codeplanks.home360.domain.user.AppUser;
 import com.codeplanks.home360.domain.user.Role;
 import com.codeplanks.home360.domain.verificationToken.VerificationToken;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,8 +48,8 @@ class VerificationTokenRepositoryTest {
             .phoneNumber("08030123456")
             .password(userPassword)
             .role(Role.USER)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now(ZoneOffset.UTC))
+            .updatedAt(ZonedDateTime.now(ZoneOffset.UTC))
             .build();
   }
 
@@ -99,8 +101,8 @@ class VerificationTokenRepositoryTest {
             .phoneNumber("08030123457")
             .password(userPassword)
             .role(Role.USER)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now(ZoneOffset.UTC))
+            .updatedAt(ZonedDateTime.now(ZoneOffset.UTC))
             .build();
     userRepository.save(appUser);
     userRepository.save(appUser2);

--- a/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/AuthenticationServiceTest.java
@@ -25,6 +25,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -122,8 +124,8 @@ class AuthenticationServiceTest {
             .phoneNumber(request.getPhoneNumber())
             .password(passwordEncoder.encode(request.getPassword()))
             .role(Role.USER)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now(ZoneOffset.UTC))
+            .updatedAt(ZonedDateTime.now(ZoneOffset.UTC))
             .build();
   }
 

--- a/src/test/java/com/codeplanks/home360/service/EnquiryMessageServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/EnquiryMessageServiceTest.java
@@ -1,0 +1,104 @@
+/* (C)2025 */
+package com.codeplanks.home360.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.codeplanks.home360.domain.listingEnquiries.EnquiryMessage;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
+import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReplyDTO;
+import com.codeplanks.home360.domain.listingEnquiries.PaginatedListingEnquiriesChat;
+import com.codeplanks.home360.repository.EnquiryMessageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class EnquiryMessageServiceTest {
+
+  @InjectMocks private EnquiryMessageServiceImpl enquiryMessageService;
+  @Mock private EnquiryMessageRepository enquiryMessageRepository;
+  @Mock private ListingEnquiryService listingEnquiryService;
+  @Mock private MongoTemplate mongoTemplate;
+
+  private ListingEnquiry enquiry;
+  private ListingEnquiryMessageReplyDTO replyDTO;
+
+  @BeforeEach
+  void setUp() {
+    enquiry = ListingEnquiry.builder()
+        .id("enquiry123")
+        .agentId(1)
+        .userId(2)
+        .build();
+
+    replyDTO = new ListingEnquiryMessageReplyDTO();
+    replyDTO.setContent("Hello, I am interested.");
+  }
+
+  @Test
+  @DisplayName("Should successfully add a reply message and update parent timestamp")
+  void addReplyMessage_Success() {
+    // Given
+    given(listingEnquiryService.getListingEnquiryById("enquiry123")).willReturn(enquiry);
+    given(enquiryMessageRepository.save(any(EnquiryMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // When
+    EnquiryMessage result = enquiryMessageService.addReplyMessage("enquiry123", replyDTO, 1);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).isEqualTo("Hello, I am interested.");
+    assertThat(result.getSenderId()).isEqualTo(1);
+    assertThat(result.getReceiverId()).isEqualTo(2);
+    
+    // Verify atomic update on parent
+    verify(mongoTemplate).updateFirst(any(Query.class), any(Update.class), eq(ListingEnquiry.class));
+    verify(enquiryMessageRepository).save(any(EnquiryMessage.class));
+  }
+
+  @Test
+  @DisplayName("Should throw exception when reply DTO is null")
+  void addReplyMessage_NullReply_ThrowsException() {
+    assertThrows(IllegalArgumentException.class, 
+        () -> enquiryMessageService.addReplyMessage("enquiry123", null, 1));
+  }
+
+  @Test
+  @DisplayName("Should return paginated messages for a valid enquiry")
+  void getEnquiryMessages_Success() {
+    // Given
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    List<EnquiryMessage> messageList = List.of(
+        EnquiryMessage.builder().content("Message 1").build(),
+        EnquiryMessage.builder().content("Message 2").build()
+    );
+    Page<EnquiryMessage> messagePage = new PageImpl<>(messageList, pageable, 2);
+    
+    given(enquiryMessageRepository.findByEnquiryId(eq("enquiry123"), any(Pageable.class)))
+        .willReturn(messagePage);
+
+    // When
+    PaginatedListingEnquiriesChat result = enquiryMessageService.getEnquiryMessages("enquiry123", 0, 10);
+
+    // Then
+    assertThat(result.getItems()).hasSize(2);
+    assertThat(result.getTotalItems()).isEqualTo(2);
+    verify(listingEnquiryService).getListingEnquiryById("enquiry123");
+  }
+}

--- a/src/test/java/com/codeplanks/home360/service/EnquiryMessageServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/EnquiryMessageServiceTest.java
@@ -1,4 +1,4 @@
-/* (C)2025 */
+/* (C)2025-2026 */
 package com.codeplanks.home360.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,6 +13,7 @@ import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiry;
 import com.codeplanks.home360.domain.listingEnquiries.ListingEnquiryMessageReplyDTO;
 import com.codeplanks.home360.domain.listingEnquiries.PaginatedListingEnquiriesChat;
 import com.codeplanks.home360.repository.EnquiryMessageRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,6 @@ import org.springframework.data.domain.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
-import java.time.ZonedDateTime;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class EnquiryMessageServiceTest {
@@ -40,11 +39,7 @@ class EnquiryMessageServiceTest {
 
   @BeforeEach
   void setUp() {
-    enquiry = ListingEnquiry.builder()
-        .id("enquiry123")
-        .agentId(1)
-        .userId(2)
-        .build();
+    enquiry = ListingEnquiry.builder().id("enquiry123").agentId(1).userId(2).build();
 
     replyDTO = new ListingEnquiryMessageReplyDTO();
     replyDTO.setContent("Hello, I am interested.");
@@ -66,16 +61,18 @@ class EnquiryMessageServiceTest {
     assertThat(result.getContent()).isEqualTo("Hello, I am interested.");
     assertThat(result.getSenderId()).isEqualTo(1);
     assertThat(result.getReceiverId()).isEqualTo(2);
-    
+
     // Verify atomic update on parent
-    verify(mongoTemplate).updateFirst(any(Query.class), any(Update.class), eq(ListingEnquiry.class));
+    verify(mongoTemplate)
+        .updateFirst(any(Query.class), any(Update.class), eq(ListingEnquiry.class));
     verify(enquiryMessageRepository).save(any(EnquiryMessage.class));
   }
 
   @Test
   @DisplayName("Should throw exception when reply DTO is null")
   void addReplyMessage_NullReply_ThrowsException() {
-    assertThrows(IllegalArgumentException.class, 
+    assertThrows(
+        IllegalArgumentException.class,
         () -> enquiryMessageService.addReplyMessage("enquiry123", null, 1));
   }
 
@@ -84,17 +81,18 @@ class EnquiryMessageServiceTest {
   void getEnquiryMessages_Success() {
     // Given
     Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    List<EnquiryMessage> messageList = List.of(
-        EnquiryMessage.builder().content("Message 1").build(),
-        EnquiryMessage.builder().content("Message 2").build()
-    );
+    List<EnquiryMessage> messageList =
+        List.of(
+            EnquiryMessage.builder().content("Message 1").build(),
+            EnquiryMessage.builder().content("Message 2").build());
     Page<EnquiryMessage> messagePage = new PageImpl<>(messageList, pageable, 2);
-    
+
     given(enquiryMessageRepository.findByEnquiryId(eq("enquiry123"), any(Pageable.class)))
         .willReturn(messagePage);
 
     // When
-    PaginatedListingEnquiriesChat result = enquiryMessageService.getEnquiryMessages("enquiry123", 0, 10);
+    PaginatedListingEnquiriesChat result =
+        enquiryMessageService.getEnquiryMessages("enquiry123", 0, 10);
 
     // Then
     assertThat(result.getItems()).hasSize(2);

--- a/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
@@ -13,10 +13,12 @@ import com.codeplanks.home360.domain.user.AppUser;
 import com.codeplanks.home360.domain.user.Role;
 import com.codeplanks.home360.exception.NotFoundException;
 import com.codeplanks.home360.repository.ListingEnquiryRepository;
+import com.codeplanks.home360.repository.EnquiryMessageRepository;
 import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.mongodb.client.result.UpdateResult;
 import jakarta.validation.*;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -41,6 +43,7 @@ class ListingEnquiryServiceTest {
   @Mock AuthenticationUtils authenticationUtils;
   @Mock ListingServiceImpl listingService;
   @Mock private ListingEnquiryRepository listingEnquiryRepository;
+  @Mock private EnquiryMessageRepository enquiryMessageRepository;
   @Mock private MongoTemplate mongoTemplate;
   @Mock private UserServiceImpl userService;
   @Mock private RedisTemplate<String, ListingWithAgentInfo> redisTemplate;
@@ -64,7 +67,7 @@ class ListingEnquiryServiceTest {
             .commercialPurpose("NO")
             .listingId("66ee668716a31f4e7fbc9e42")
             .agentId(1)
-            .createdAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now())
             .build();
 
     john =
@@ -108,7 +111,7 @@ class ListingEnquiryServiceTest {
             .location("London")
             .listingId("66ee668716a31f4e7fbc9e42")
             .agentId(1)
-            .createdAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now())
             .build();
     given(authenticationUtils.isAuthenticated()).willReturn(false);
     given(listingEnquiryRepository.save(any(ListingEnquiry.class))).willReturn(savedEnquiry);
@@ -211,7 +214,7 @@ class ListingEnquiryServiceTest {
             .location("London")
             .listingId("66ee668716a31f4e7fbc9e42")
             .agentId(1)
-            .createdAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now())
             .build();
     ListingEnquiry listingEnquiry2 =
         ListingEnquiry.builder()
@@ -223,15 +226,13 @@ class ListingEnquiryServiceTest {
             .location("London")
             .listingId("66ee668716a31f4e7fbc9e42")
             .agentId(1)
-            .createdAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now())
             .build();
 
     List<ListingEnquiry> enquiries = List.of(listingEnquiry1, listingEnquiry2);
     Page<ListingEnquiry> mockPage = new PageImpl<>(enquiries, PageRequest.of(page, size), 2);
-    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "created_at");
+    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
     //    given(userService.extractUserId()).willReturn(agentId);
-    given(listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable))
-        .willReturn(mockPage);
     given(listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable))
         .willReturn(mockPage);
 
@@ -252,24 +253,6 @@ class ListingEnquiryServiceTest {
     verify(listingEnquiryRepository, times(1)).findListingEnquiries(agentId, senderId, pageable);
   }
 
-  //  @Test
-  //  @DisplayName("Failed user ID extraction")
-  //  void givenInvalidUserIdWhenUserFetchDataThenThrowException() {
-  //    // Given
-  //    int agentId = 1;
-  //    given(userService.extractUserId()).willThrow(new RuntimeException("User not
-  // authenticated"));
-  //
-  //    // When
-  //    RuntimeException exception =
-  //        assertThrows(
-  //            RuntimeException.class, () -> listingEnquiryService.getListingEnquiries(0, 5, null,
-  //                        agentId));
-  //
-  //    // Then
-  //    assertThat(exception.getMessage()).isEqualTo("User not authenticated");
-  //    verify(listingEnquiryRepository, never()).findListingEnquiries(anyInt(), any(), any());
-  //  }
 
   @Test
   @DisplayName("Zero listing enquiries found")
@@ -277,8 +260,7 @@ class ListingEnquiryServiceTest {
     // Given
     int page = 0, size = 5;
     Integer agentId = 1;
-    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "created_at");
-    //    given(userService.extractUserId()).willReturn(agentId);
+    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
     given(listingEnquiryRepository.findListingEnquiries(agentId, null, pageable))
         .willReturn(Page.empty());
 
@@ -340,7 +322,7 @@ class ListingEnquiryServiceTest {
     int page = 0, size = 5;
     Integer agentId = 1;
     Integer invalidSenderId = -999;
-    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "created_at");
+    Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
 
     //    given(userService.extractUserId()).willReturn(agentId);
     given(listingEnquiryRepository.findListingEnquiries(agentId, invalidSenderId, pageable))
@@ -371,7 +353,7 @@ class ListingEnquiryServiceTest {
             .location("London")
             .listingId("66ee668716a31f4e7fbc9e42")
             .agentId(1)
-            .createdAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now())
             .build();
 
     given(userService.extractUserId()).willReturn(agentId);
@@ -424,7 +406,7 @@ class ListingEnquiryServiceTest {
             .location("London")
             .listingId("66ee668716a31f4e7fbc9e42")
             .agentId(agentId)
-            .createdAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now())
             .build();
 
     given(listingEnquiryRepository.findById(listingEnquiryId))
@@ -618,123 +600,6 @@ class ListingEnquiryServiceTest {
 
     // Then
     assertThat(result).isFalse();
-  }
-
-  @Test
-  @DisplayName("Add reply message successfully")
-  void givenValidInputWhenAddReplyMessageThenSuccess() {
-    // Given
-    String enquiryMessageId = "64bd652852212f03ee0d2158";
-    int senderId = 1;
-    ListingEnquiryMessageReplyDTO replyDTO =
-        new ListingEnquiryMessageReplyDTO(1, 2, "Hello", enquiryMessageId, senderId);
-    Query query = new Query(Criteria.where("_id").is(enquiryMessageId));
-    // Mock the dependencies
-    // given(userService.getUserByUserId(1)).willReturn(john);
-    // given(userService.getUserByUserId(2)).willReturn(jane);
-    given(mongoTemplate.updateFirst(any(Query.class), any(Update.class), eq(ListingEnquiry.class)))
-        .willReturn(UpdateResult.acknowledged(1L, 1L, null));
-
-    // When
-    ListingEnquiryMessageReply result =
-        listingEnquiryService.addReplyMessage(enquiryMessageId, replyDTO, 1);
-
-    // Then
-    assertThat(result).isNotNull();
-    assertThat(result.getSenderId()).isEqualTo(1);
-    assertThat(result.getEnquirerId()).isEqualTo(2);
-    assertThat(result.getContent()).isEqualTo("Hello");
-  }
-
-  @Test
-  @DisplayName("Enquiry ID not found")
-  void givenInvalidEnquiryIdWhenAddReplyMessageThenThrowNotFoundException() {
-    // Given
-    String invalidEnquiryMessageId = "invalid-id";
-    int senderId = 1;
-    ListingEnquiryMessageReplyDTO replyDTO =
-        new ListingEnquiryMessageReplyDTO(1, 2, "Hello", invalidEnquiryMessageId, senderId);
-    Query query = new Query(Criteria.where("_id").is(invalidEnquiryMessageId));
-
-    // given(userService.getUserByUserId(1)).willReturn(john);
-    // given(userService.getUserByUserId(2)).willReturn(jane);
-    given(mongoTemplate.updateFirst(any(Query.class), any(Update.class), eq(ListingEnquiry.class)))
-        .willReturn(UpdateResult.acknowledged(0L, 0L, null));
-
-    // When
-    AccessDeniedException exception =
-        assertThrows(
-            AccessDeniedException.class,
-            () ->
-                listingEnquiryService.addReplyMessage(invalidEnquiryMessageId, replyDTO, senderId));
-
-    // Then
-    assertThat(exception.getMessage()).isEqualTo("Enquiry not found or you are not authorized to reply to it.");
-  }
-
-  @Test
-  @DisplayName("Reply DTO is null")
-  void givenNullReplyDTOWhenAddReplyMessageThenThrowIllegalArgumentException() {
-    // Given
-    String enquiryMessageId = "64bd652852212f03ee0d2158";
-    int senderId = 1;
-
-    // When
-    IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> listingEnquiryService.addReplyMessage(enquiryMessageId, null, senderId));
-
-    // Then
-    assertThat(exception.getMessage()).isEqualTo("Message reply cannot be null or blank");
-  }
-
-  @Test
-  @DisplayName("Sender or receiver user not found")
-  void givenInvalidUserId_whenAddReplyMessage_thenThrowNotFoundException() {
-    // Given
-    String enquiryMessageId = "64bd652852212f03ee0d2158";
-    int senderId = 1;
-    ListingEnquiryMessageReplyDTO replyDTO =
-        new ListingEnquiryMessageReplyDTO(99, 100, "Hello", enquiryMessageId, senderId);
-
-    // given(userService.getUserByUserId(99)).willThrow(new NotFoundException("User not found"));
-    given(mongoTemplate.updateFirst(any(Query.class), any(Update.class), eq(ListingEnquiry.class)))
-        .willReturn(UpdateResult.acknowledged(0L, 0L, null));
-
-    // When
-    AccessDeniedException exception =
-        assertThrows(
-            AccessDeniedException.class,
-            () -> listingEnquiryService.addReplyMessage(enquiryMessageId, replyDTO, senderId));
-
-    // Then
-    assertThat(exception.getMessage()).isEqualTo("Enquiry not found or you are not authorized to reply to it.");
-  }
-
-  @Test
-  @DisplayName("Enquiry ID found but no modification made")
-  void givenValidEnquiryIdButNoModification_whenAddReplyMessage_thenThrowNotFoundException() {
-    // Given
-    String enquiryMessageId = "64bd652852212f03ee0d2158";
-    int senderId = 1;
-    ListingEnquiryMessageReplyDTO replyDTO =
-        new ListingEnquiryMessageReplyDTO(1, 2, "Hello", enquiryMessageId, senderId);
-    Query query = new Query(Criteria.where("_id").is(enquiryMessageId));
-
-    // given(userService.getUserByUserId(1)).willReturn(john);
-    // given(userService.getUserByUserId(2)).willReturn(jane);
-    given(mongoTemplate.updateFirst(any(Query.class), any(Update.class), eq(ListingEnquiry.class)))
-        .willReturn(UpdateResult.acknowledged(0L, 0L, null));
-
-    // When
-    AccessDeniedException exception =
-        assertThrows(
-            AccessDeniedException.class,
-            () -> listingEnquiryService.addReplyMessage(enquiryMessageId, replyDTO, senderId));
-
-    // Then
-    assertThat(exception.getMessage()).isEqualTo("Enquiry not found or you are not authorized to reply to it.");
   }
 
   @Test

--- a/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
@@ -79,8 +79,8 @@ class ListingEnquiryServiceTest {
             "1245678",
             "221B Baker street",
             "080212345678",
-            LocalDateTime.now(),
-            LocalDateTime.now(),
+            ZonedDateTime.now(),
+            ZonedDateTime.now(),
             Role.USER,
             true);
     jane =
@@ -92,8 +92,8 @@ class ListingEnquiryServiceTest {
             "1245678",
             "221C Butler street",
             "080212345687",
-            LocalDateTime.now(),
-            LocalDateTime.now(),
+            ZonedDateTime.now(),
+            ZonedDateTime.now(),
             Role.USER,
             true);
   }
@@ -233,12 +233,12 @@ class ListingEnquiryServiceTest {
     Page<ListingEnquiry> mockPage = new PageImpl<>(enquiries, PageRequest.of(page, size), 2);
     Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
     //    given(userService.extractUserId()).willReturn(agentId);
-    given(listingEnquiryRepository.findListingEnquiries(agentId, senderId, pageable))
+    given(listingEnquiryRepository.findListingEnquiries(agentId, senderId, null, pageable))
         .willReturn(mockPage);
 
     // When
     PaginatedListingEnquiriesResponse result =
-        listingEnquiryService.getListingEnquiries(0, 5, 1, agentId);
+        listingEnquiryService.getListingEnquiries(0, 5, 1, agentId, null);
 
     // Then
     assertAll(
@@ -250,7 +250,7 @@ class ListingEnquiryServiceTest {
         () -> assertThat(result.getItems()).hasSize(2),
         () -> assertThat(result.isHasNext()).isFalse());
 
-    verify(listingEnquiryRepository, times(1)).findListingEnquiries(agentId, senderId, pageable);
+    verify(listingEnquiryRepository, times(1)).findListingEnquiries(agentId, senderId, null, pageable);
   }
 
   @Test
@@ -260,12 +260,12 @@ class ListingEnquiryServiceTest {
     int page = 0, size = 5;
     Integer agentId = 1;
     Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
-    given(listingEnquiryRepository.findListingEnquiries(agentId, null, pageable))
+    given(listingEnquiryRepository.findListingEnquiries(agentId, null, null, pageable))
         .willReturn(Page.empty());
 
     // When
     PaginatedListingEnquiriesResponse response =
-        listingEnquiryService.getListingEnquiries(page, size, null, agentId);
+        listingEnquiryService.getListingEnquiries(page, size, null, agentId, null);
 
     // Then
     assertAll(
@@ -286,11 +286,11 @@ class ListingEnquiryServiceTest {
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> listingEnquiryService.getListingEnquiries(page, size, null, agentId));
+            () -> listingEnquiryService.getListingEnquiries(page, size, null, agentId, null));
 
     // Then
     assertThat(exception.getMessage()).isEqualTo("Page index must not be less than zero");
-    verify(listingEnquiryRepository, never()).findListingEnquiries(anyInt(), any(), any());
+    verify(listingEnquiryRepository, never()).findListingEnquiries(anyInt(), any(), any(), any());
   }
 
   @Test
@@ -301,14 +301,14 @@ class ListingEnquiryServiceTest {
     Integer agentId = 1;
 
     //    given(userService.extractUserId()).willReturn(agentId);
-    given(listingEnquiryRepository.findListingEnquiries(anyInt(), any(), any()))
+    given(listingEnquiryRepository.findListingEnquiries(anyInt(), any(), any(), any()))
         .willThrow(new RuntimeException("Database error"));
 
     // When
     RuntimeException exception =
         assertThrows(
             RuntimeException.class,
-            () -> listingEnquiryService.getListingEnquiries(page, size, null, agentId));
+            () -> listingEnquiryService.getListingEnquiries(page, size, null, agentId, null));
 
     // Then
     assertThat(exception.getMessage()).isEqualTo("Database error");
@@ -324,12 +324,12 @@ class ListingEnquiryServiceTest {
     Pageable pageable = PageRequest.of(page, size).withSort(Sort.Direction.DESC, "last_message_at");
 
     //    given(userService.extractUserId()).willReturn(agentId);
-    given(listingEnquiryRepository.findListingEnquiries(agentId, invalidSenderId, pageable))
+    given(listingEnquiryRepository.findListingEnquiries(agentId, invalidSenderId, null, pageable))
         .willReturn(Page.empty());
 
     // When
     PaginatedListingEnquiriesResponse response =
-        listingEnquiryService.getListingEnquiries(page, size, invalidSenderId, agentId);
+        listingEnquiryService.getListingEnquiries(page, size, invalidSenderId, agentId, null);
 
     // Then
     assertThat(response).isNotNull();
@@ -508,14 +508,12 @@ class ListingEnquiryServiceTest {
     ListingEnquiry listingEnquiry =
         ListingEnquiry.builder()
             .id(enquiryMessageId)
-            .agentId(1) // Matching the user ID for authorization
-            .read(false)
+            .agentId(1)
+            .status(EnquiryStatus.PENDING)
+            .unreadCountByAgent(1)
             .build();
 
-    Query query = new Query(Criteria.where("_id").is(enquiryMessageId));
-
-    given(mongoTemplate.exists(query, ListingEnquiry.class)).willReturn(true);
-    given(mongoTemplate.findOne(query, ListingEnquiry.class)).willReturn(listingEnquiry);
+    given(listingEnquiryRepository.findById(enquiryMessageId)).willReturn(Optional.of(listingEnquiry));
     given(userService.extractUserId()).willReturn(1);
 
     UpdateResult updateResult = mock(UpdateResult.class);
@@ -528,6 +526,7 @@ class ListingEnquiryServiceTest {
 
     // Then
     assertThat(result).isTrue();
+    verify(listingEnquiryRepository, times(1)).findById(enquiryMessageId);
   }
 
   @Test
@@ -535,8 +534,7 @@ class ListingEnquiryServiceTest {
   void givenInvalidEnquiryIdWhenMarkEnquiryAsReadThenThrowNotFoundException() {
     // Given
     String enquiryMessageId = "invalid_id";
-    Query query = new Query(Criteria.where("_id").is(enquiryMessageId));
-    given(mongoTemplate.exists(query, ListingEnquiry.class)).willReturn(false);
+    given(listingEnquiryRepository.findById(enquiryMessageId)).willReturn(Optional.empty());
 
     // When
     NotFoundException exception =
@@ -545,7 +543,7 @@ class ListingEnquiryServiceTest {
             () -> listingEnquiryService.markEnquiryAsRead(enquiryMessageId));
 
     // Then
-    assertThat(exception.getMessage()).isEqualTo("Listing enquiry with the given ID was not found");
+    assertThat(exception.getMessage()).isEqualTo("Listing enquiry not found");
   }
 
   @Test
@@ -559,9 +557,7 @@ class ListingEnquiryServiceTest {
             .agentId(2) // Different agent ID
             .build();
 
-    Query query = new Query(Criteria.where("_id").is(enquiryMessageId));
-    given(mongoTemplate.exists(query, ListingEnquiry.class)).willReturn(true);
-    given(mongoTemplate.findOne(query, ListingEnquiry.class)).willReturn(listingEnquiry);
+    given(listingEnquiryRepository.findById(enquiryMessageId)).willReturn(Optional.of(listingEnquiry));
     given(userService.extractUserId()).willReturn(1); // User ID does not match agent ID
 
     // When
@@ -572,7 +568,7 @@ class ListingEnquiryServiceTest {
 
     // Then
     assertThat(exception.getMessage())
-        .isEqualTo("Forbidden. You're not authorized to access this data");
+        .isEqualTo("You are not authorized to mark this conversation as read");
   }
 
   @Test
@@ -581,12 +577,9 @@ class ListingEnquiryServiceTest {
     // Given
     String enquiryMessageId = "64bd652852212f03ee0d2158";
     ListingEnquiry listingEnquiry =
-        ListingEnquiry.builder().id(enquiryMessageId).agentId(1).read(false).build();
+        ListingEnquiry.builder().id(enquiryMessageId).agentId(1).build();
 
-    Query query = new Query(Criteria.where("_id").is(enquiryMessageId));
-
-    given(mongoTemplate.exists(query, ListingEnquiry.class)).willReturn(true);
-    given(mongoTemplate.findOne(query, ListingEnquiry.class)).willReturn(listingEnquiry);
+    given(listingEnquiryRepository.findById(enquiryMessageId)).willReturn(Optional.of(listingEnquiry));
     given(userService.extractUserId()).willReturn(1);
 
     UpdateResult updateResult = mock(UpdateResult.class);

--- a/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
@@ -17,7 +17,6 @@ import com.codeplanks.home360.repository.ListingEnquiryRepository;
 import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.mongodb.client.result.UpdateResult;
 import jakarta.validation.*;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +28,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -250,7 +248,8 @@ class ListingEnquiryServiceTest {
         () -> assertThat(result.getItems()).hasSize(2),
         () -> assertThat(result.isHasNext()).isFalse());
 
-    verify(listingEnquiryRepository, times(1)).findListingEnquiries(agentId, senderId, null, pageable);
+    verify(listingEnquiryRepository, times(1))
+        .findListingEnquiries(agentId, senderId, null, pageable);
   }
 
   @Test
@@ -513,7 +512,8 @@ class ListingEnquiryServiceTest {
             .unreadCountByAgent(1)
             .build();
 
-    given(listingEnquiryRepository.findById(enquiryMessageId)).willReturn(Optional.of(listingEnquiry));
+    given(listingEnquiryRepository.findById(enquiryMessageId))
+        .willReturn(Optional.of(listingEnquiry));
     given(userService.extractUserId()).willReturn(1);
 
     UpdateResult updateResult = mock(UpdateResult.class);
@@ -557,7 +557,8 @@ class ListingEnquiryServiceTest {
             .agentId(2) // Different agent ID
             .build();
 
-    given(listingEnquiryRepository.findById(enquiryMessageId)).willReturn(Optional.of(listingEnquiry));
+    given(listingEnquiryRepository.findById(enquiryMessageId))
+        .willReturn(Optional.of(listingEnquiry));
     given(userService.extractUserId()).willReturn(1); // User ID does not match agent ID
 
     // When
@@ -579,7 +580,8 @@ class ListingEnquiryServiceTest {
     ListingEnquiry listingEnquiry =
         ListingEnquiry.builder().id(enquiryMessageId).agentId(1).build();
 
-    given(listingEnquiryRepository.findById(enquiryMessageId)).willReturn(Optional.of(listingEnquiry));
+    given(listingEnquiryRepository.findById(enquiryMessageId))
+        .willReturn(Optional.of(listingEnquiry));
     given(userService.extractUserId()).willReturn(1);
 
     UpdateResult updateResult = mock(UpdateResult.class);

--- a/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
@@ -1,4 +1,4 @@
-/* (C)2024-2025 */
+/* (C)2024-2026 */
 package com.codeplanks.home360.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,8 +12,8 @@ import com.codeplanks.home360.domain.listingEnquiries.*;
 import com.codeplanks.home360.domain.user.AppUser;
 import com.codeplanks.home360.domain.user.Role;
 import com.codeplanks.home360.exception.NotFoundException;
-import com.codeplanks.home360.repository.ListingEnquiryRepository;
 import com.codeplanks.home360.repository.EnquiryMessageRepository;
+import com.codeplanks.home360.repository.ListingEnquiryRepository;
 import com.codeplanks.home360.utils.AuthenticationUtils;
 import com.mongodb.client.result.UpdateResult;
 import jakarta.validation.*;
@@ -252,7 +252,6 @@ class ListingEnquiryServiceTest {
 
     verify(listingEnquiryRepository, times(1)).findListingEnquiries(agentId, senderId, pageable);
   }
-
 
   @Test
   @DisplayName("Zero listing enquiries found")

--- a/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
@@ -503,7 +503,7 @@ class ListingEnquiryServiceTest {
 
   @Test
   @DisplayName("Mark message as read successfully")
-  void givenValidEnquiryIdWhenMarkMessageAsReadThenReturnTrue() {
+  void givenValidEnquiryIdWhenMarkEnquiryAsReadThenReturnTrue() {
     // Given
     String enquiryMessageId = "64bd652852212f03ee0d2158";
     ListingEnquiry listingEnquiry =
@@ -525,7 +525,7 @@ class ListingEnquiryServiceTest {
         .willReturn(updateResult);
 
     // When
-    Boolean result = listingEnquiryService.markMessageAsRead(enquiryMessageId);
+    Boolean result = listingEnquiryService.markEnquiryAsRead(enquiryMessageId);
 
     // Then
     assertThat(result).isTrue();
@@ -533,7 +533,7 @@ class ListingEnquiryServiceTest {
 
   @Test
   @DisplayName("Enquiry ID does not exist")
-  void givenInvalidEnquiryIdWhenMarkMessageAsReadThenThrowNotFoundException() {
+  void givenInvalidEnquiryIdWhenMarkEnquiryAsReadThenThrowNotFoundException() {
     // Given
     String enquiryMessageId = "invalid_id";
     Query query = new Query(Criteria.where("_id").is(enquiryMessageId));
@@ -543,7 +543,7 @@ class ListingEnquiryServiceTest {
     NotFoundException exception =
         assertThrows(
             NotFoundException.class,
-            () -> listingEnquiryService.markMessageAsRead(enquiryMessageId));
+            () -> listingEnquiryService.markEnquiryAsRead(enquiryMessageId));
 
     // Then
     assertThat(exception.getMessage()).isEqualTo("Listing enquiry with the given ID was not found");
@@ -551,7 +551,7 @@ class ListingEnquiryServiceTest {
 
   @Test
   @DisplayName("AccessDeniedException when user is not authorized")
-  void givenUnauthorizedUserWhenMarkMessageAsReadThenThrowAccessDeniedException() {
+  void givenUnauthorizedUserWhenMarkEnquiryAsReadThenThrowAccessDeniedException() {
     // Given
     String enquiryMessageId = "64bd652852212f03ee0d2158";
     ListingEnquiry listingEnquiry =
@@ -569,7 +569,7 @@ class ListingEnquiryServiceTest {
     AccessDeniedException exception =
         assertThrows(
             AccessDeniedException.class,
-            () -> listingEnquiryService.markMessageAsRead(enquiryMessageId));
+            () -> listingEnquiryService.markEnquiryAsRead(enquiryMessageId));
 
     // Then
     assertThat(exception.getMessage())
@@ -578,7 +578,7 @@ class ListingEnquiryServiceTest {
 
   @Test
   @DisplayName("Return false if message was not updated")
-  void givenValidEnquiryId_whenMarkMessageAsReadButNotModified_thenReturnFalse() {
+  void givenValidEnquiryId_whenMarkEnquiryAsReadButNotModified_thenReturnFalse() {
     // Given
     String enquiryMessageId = "64bd652852212f03ee0d2158";
     ListingEnquiry listingEnquiry =
@@ -596,7 +596,7 @@ class ListingEnquiryServiceTest {
         .willReturn(updateResult);
 
     // When
-    Boolean result = listingEnquiryService.markMessageAsRead(enquiryMessageId);
+    Boolean result = listingEnquiryService.markEnquiryAsRead(enquiryMessageId);
 
     // Then
     assertThat(result).isFalse();

--- a/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingEnquiryServiceTest.java
@@ -569,7 +569,7 @@ class ListingEnquiryServiceTest {
 
     // Then
     assertThat(exception.getMessage())
-        .isEqualTo("You are not authorized to mark this conversation as read");
+        .isEqualTo("Forbidden. You're not authorized to access this data");
   }
 
   @Test

--- a/src/test/java/com/codeplanks/home360/service/ListingServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/ListingServiceTest.java
@@ -13,6 +13,8 @@ import com.codeplanks.home360.exception.NotFoundException;
 import com.codeplanks.home360.exception.UnAuthorizedException;
 import com.codeplanks.home360.repository.ListingRepository;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,8 +55,8 @@ class ListingServiceTest {
             .password("1245678")
             .role(Role.USER)
             .isEnabled(true)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now(ZoneOffset.UTC))
+            .updatedAt(ZonedDateTime.now(ZoneOffset.UTC))
             .build();
 
     listingDTO =

--- a/src/test/java/com/codeplanks/home360/service/VerificationTokenServiceTest.java
+++ b/src/test/java/com/codeplanks/home360/service/VerificationTokenServiceTest.java
@@ -17,6 +17,8 @@ import com.codeplanks.home360.repository.VerificationTokenRepository;
 import jakarta.mail.MessagingException;
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,8 +56,8 @@ class VerificationTokenServiceTest {
             .phoneNumber("08030123456")
             .password(userPassword)
             .role(Role.USER)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(ZonedDateTime.now(ZoneOffset.UTC))
+            .updatedAt(ZonedDateTime.now(ZoneOffset.UTC))
             .build();
   }
 


### PR DESCRIPTION
## What does this PR do?
  This PR refactors the property enquiry system by decoupling chat messages from the parent enquiry document into a dedicated collection. It also implements paginated chat history, conversation-level unread message counters, a formal lifecycle status for enquiries (PENDING, ACTIVE, etc.), and critical security fixes for distributed rate limiting and PII data caching.

##   Description of Task to be completed?
   - [x] Architectural Refactor: Extracted embedded message replies into a standalone EnquiryMessage MongoDB collection.
   - [x] Chat History: Implemented `GET /api/v1/listing-enquiries/{enquiryId}/messages` with pagination support.
   - [x] Notification System: Replaced boolean read flags with atomic integer counters (unreadCountByAgent, unreadCountByInquirer) to support "X unread messages" badges.
   - [x] Lifecycle Management: Added EnquiryStatus enum (PENDING, ACTIVE, ARCHIVED, COMPLETED) and logic to auto-transition leads from PENDING to ACTIVE upon agent acknowledgement.
   - [x] Security Fixes:
   - [x] Migrated from ConcurrentHashMap to Caffeine Cache in RateLimitingFilter and WebSocket interceptors to prevent memory exhaustion and implement TTL.
  - [x] Fixed a PII leak in `@Cacheable` services by partitioning cache keys by userId.
  - [x] Sanitized WebSocket error responses to prevent internal stack trace leakage.
  - [x] Global Unread Count: Added `GET /api/v1/listing-enquiries/unread-count` to aggregate total unread messages across all property enquiries for the authenticated user.

##   How should this be manually tested?
   1. Lead Creation: Create a new enquiry using `POST /api/v1/listing-enquiries`. Verify unreadCountByAgent is 1 and status is PENDING.
   2. Chatting: Use the WebSocket /chat/{enquiryId}/sendMessage endpoint to exchange messages. Verify that the recipient's unreadCount increments and the sender's resets to 0.
   3. Pagination: Fetch history via `GET /api/v1/listing-enquiries/{enquiryId}/messages?page=1&size=5.`
   4. Read Status: Call `PATCH /api/v1/listing-enquiries/{id}/read` as an agent. Verify status changes to ACTIVE and unreadCountByAgent becomes 0.
   5. Security: Attempt to fetch an enquiry ID you don't own via the REST API or WebSocket subscription. Verify 403 Forbidden or AccessDenied is returned.

##   Any background context you want to provide?
  The move to a separate EnquiryMessage collection was necessary to avoid the 16MB MongoDB document limit on long-running property negotiations and to allow for efficient "infinite scroll" or paginated message loading in the UI. The caching refactor was prompted by the need for better memory management and to prepare the app for future horizontal scaling.

##   What are the relevant Jira board stories?
 [ HOM-177](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-177)